### PR TITLE
change to use mysql instead of sqlite

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,8 @@ gem 'worthwhile', '~> 0.1.0'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.0.4'
 
-# Use sqlite3 as the database for Active Record
-gem 'sqlite3'
+# Use mysql as the database for Active Record
+gem 'mysql2'
 
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 4.0.2'

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,11 +1,13 @@
-# SQLite version 3.x
-#   gem install sqlite3
+# This file will be overwritten by configuration manager
+#   gem install mysql2 
 #
-#   Ensure the SQLite 3 gem is defined in your Gemfile
-#   gem 'sqlite3'
+#   Ensure the MySQL 2 gem is defined in your Gemfile
+#   gem 'mysql2'
 development:
-  adapter: sqlite3
-  database: db/development.sqlite3
+  adapter: mysql2
+  database: hydranorthdev
+  username:
+  password:
   pool: 5
   timeout: 5000
 
@@ -13,13 +15,17 @@ development:
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  adapter: sqlite3
-  database: db/test.sqlite3
+  adapter: mysql2
+  database: hydranorthtest
+  username:
+  password:
   pool: 5
   timeout: 5000
 
 production:
-  adapter: sqlite3
-  database: db/production.sqlite3
+  adapter: mysql2
+  database: hydranorthprod
+  username:
+  password:
   pool: 5
   timeout: 5000

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -23,7 +23,7 @@ ActiveRecord::Schema.define(version: 20141009173360) do
     t.string   "document_type"
   end
 
-  add_index "bookmarks", ["user_id"], name: "index_bookmarks_on_user_id"
+  add_index "bookmarks", ["user_id"], name: "index_bookmarks_on_user_id", using: :btree
 
   create_table "checksum_audit_logs", force: true do |t|
     t.string   "pid"
@@ -36,7 +36,7 @@ ActiveRecord::Schema.define(version: 20141009173360) do
     t.datetime "updated_at"
   end
 
-  add_index "checksum_audit_logs", ["pid", "dsid"], name: "by_pid_and_dsid"
+  add_index "checksum_audit_logs", ["pid", "dsid"], name: "by_pid_and_dsid", using: :btree
 
   create_table "content_blocks", force: true do |t|
     t.string   "name"
@@ -45,22 +45,22 @@ ActiveRecord::Schema.define(version: 20141009173360) do
     t.datetime "updated_at"
   end
 
-  add_index "content_blocks", ["name"], name: "index_content_blocks_on_name", unique: true
+  add_index "content_blocks", ["name"], name: "index_content_blocks_on_name", unique: true, using: :btree
 
   create_table "domain_terms", force: true do |t|
     t.string "model"
     t.string "term"
   end
 
-  add_index "domain_terms", ["model", "term"], name: "terms_by_model_and_term"
+  add_index "domain_terms", ["model", "term"], name: "terms_by_model_and_term", using: :btree
 
   create_table "domain_terms_local_authorities", id: false, force: true do |t|
     t.integer "domain_term_id"
     t.integer "local_authority_id"
   end
 
-  add_index "domain_terms_local_authorities", ["domain_term_id", "local_authority_id"], name: "dtla_by_ids2"
-  add_index "domain_terms_local_authorities", ["local_authority_id", "domain_term_id"], name: "dtla_by_ids1"
+  add_index "domain_terms_local_authorities", ["domain_term_id", "local_authority_id"], name: "dtla_by_ids2", using: :btree
+  add_index "domain_terms_local_authorities", ["local_authority_id", "domain_term_id"], name: "dtla_by_ids1", using: :btree
 
   create_table "featured_works", force: true do |t|
     t.integer  "order",           default: 5
@@ -69,8 +69,8 @@ ActiveRecord::Schema.define(version: 20141009173360) do
     t.datetime "updated_at"
   end
 
-  add_index "featured_works", ["generic_file_id"], name: "index_featured_works_on_generic_file_id"
-  add_index "featured_works", ["order"], name: "index_featured_works_on_order"
+  add_index "featured_works", ["generic_file_id"], name: "index_featured_works_on_generic_file_id", using: :btree
+  add_index "featured_works", ["order"], name: "index_featured_works_on_order", using: :btree
 
   create_table "follows", force: true do |t|
     t.integer  "followable_id",                   null: false
@@ -82,8 +82,8 @@ ActiveRecord::Schema.define(version: 20141009173360) do
     t.datetime "updated_at"
   end
 
-  add_index "follows", ["followable_id", "followable_type"], name: "fk_followables"
-  add_index "follows", ["follower_id", "follower_type"], name: "fk_follows"
+  add_index "follows", ["followable_id", "followable_type"], name: "fk_followables", using: :btree
+  add_index "follows", ["follower_id", "follower_type"], name: "fk_follows", using: :btree
 
   create_table "local_authorities", force: true do |t|
     t.string "name"
@@ -95,8 +95,8 @@ ActiveRecord::Schema.define(version: 20141009173360) do
     t.string  "uri"
   end
 
-  add_index "local_authority_entries", ["local_authority_id", "label"], name: "entries_by_term_and_label"
-  add_index "local_authority_entries", ["local_authority_id", "uri"], name: "entries_by_term_and_uri"
+  add_index "local_authority_entries", ["local_authority_id", "label"], name: "entries_by_term_and_label", using: :btree
+  add_index "local_authority_entries", ["local_authority_id", "uri"], name: "entries_by_term_and_uri", using: :btree
 
   create_table "mailboxer_conversation_opt_outs", force: true do |t|
     t.integer "unsubscriber_id"
@@ -104,8 +104,8 @@ ActiveRecord::Schema.define(version: 20141009173360) do
     t.integer "conversation_id"
   end
 
-  add_index "mailboxer_conversation_opt_outs", ["conversation_id"], name: "index_mailboxer_conversation_opt_outs_on_conversation_id"
-  add_index "mailboxer_conversation_opt_outs", ["unsubscriber_id", "unsubscriber_type"], name: "index_mailboxer_conversation_opt_outs_on_unsubscriber_id_type"
+  add_index "mailboxer_conversation_opt_outs", ["conversation_id"], name: "index_mailboxer_conversation_opt_outs_on_conversation_id", using: :btree
+  add_index "mailboxer_conversation_opt_outs", ["unsubscriber_id", "unsubscriber_type"], name: "index_mailboxer_conversation_opt_outs_on_unsubscriber_id_type", using: :btree
 
   create_table "mailboxer_conversations", force: true do |t|
     t.string   "subject",    default: ""
@@ -131,10 +131,10 @@ ActiveRecord::Schema.define(version: 20141009173360) do
     t.datetime "expires"
   end
 
-  add_index "mailboxer_notifications", ["conversation_id"], name: "index_mailboxer_notifications_on_conversation_id"
-  add_index "mailboxer_notifications", ["notified_object_id", "notified_object_type"], name: "index_mailboxer_notifications_on_notified_object_id_and_type"
-  add_index "mailboxer_notifications", ["sender_id", "sender_type"], name: "index_mailboxer_notifications_on_sender_id_and_sender_type"
-  add_index "mailboxer_notifications", ["type"], name: "index_mailboxer_notifications_on_type"
+  add_index "mailboxer_notifications", ["conversation_id"], name: "index_mailboxer_notifications_on_conversation_id", using: :btree
+  add_index "mailboxer_notifications", ["notified_object_id", "notified_object_type"], name: "index_mailboxer_notifications_on_notified_object_id_and_type", using: :btree
+  add_index "mailboxer_notifications", ["sender_id", "sender_type"], name: "index_mailboxer_notifications_on_sender_id_and_sender_type", using: :btree
+  add_index "mailboxer_notifications", ["type"], name: "index_mailboxer_notifications_on_type", using: :btree
 
   create_table "mailboxer_receipts", force: true do |t|
     t.integer  "receiver_id"
@@ -148,8 +148,8 @@ ActiveRecord::Schema.define(version: 20141009173360) do
     t.datetime "updated_at",                                 null: false
   end
 
-  add_index "mailboxer_receipts", ["notification_id"], name: "index_mailboxer_receipts_on_notification_id"
-  add_index "mailboxer_receipts", ["receiver_id", "receiver_type"], name: "index_mailboxer_receipts_on_receiver_id_and_receiver_type"
+  add_index "mailboxer_receipts", ["notification_id"], name: "index_mailboxer_receipts_on_notification_id", using: :btree
+  add_index "mailboxer_receipts", ["receiver_id", "receiver_type"], name: "index_mailboxer_receipts_on_receiver_id_and_receiver_type", using: :btree
 
   create_table "searches", force: true do |t|
     t.text     "query_params"
@@ -159,7 +159,7 @@ ActiveRecord::Schema.define(version: 20141009173360) do
     t.datetime "updated_at"
   end
 
-  add_index "searches", ["user_id"], name: "index_searches_on_user_id"
+  add_index "searches", ["user_id"], name: "index_searches_on_user_id", using: :btree
 
   create_table "single_use_links", force: true do |t|
     t.string   "downloadKey"
@@ -176,7 +176,7 @@ ActiveRecord::Schema.define(version: 20141009173360) do
     t.string "url"
   end
 
-  add_index "subject_local_authority_entries", ["lowerLabel"], name: "entries_by_lower_label"
+  add_index "subject_local_authority_entries", ["lowerLabel"], name: "entries_by_lower_label", using: :btree
 
   create_table "tinymce_assets", force: true do |t|
     t.string   "file"
@@ -227,8 +227,8 @@ ActiveRecord::Schema.define(version: 20141009173360) do
     t.string   "linkedin_handle"
   end
 
-  add_index "users", ["email"], name: "index_users_on_email", unique: true
-  add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
+  add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
+  add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
 
   create_table "version_committers", force: true do |t|
     t.string   "obj_id"
@@ -238,5 +238,11 @@ ActiveRecord::Schema.define(version: 20141009173360) do
     t.datetime "created_at"
     t.datetime "updated_at"
   end
+
+  add_foreign_key "mailboxer_conversation_opt_outs", "mailboxer_conversations", name: "mb_opt_outs_on_conversations_id", column: "conversation_id"
+
+  add_foreign_key "mailboxer_notifications", "mailboxer_conversations", name: "notifications_on_conversation_id", column: "conversation_id"
+
+  add_foreign_key "mailboxer_receipts", "mailboxer_notifications", name: "receipts_on_notification_id", column: "notification_id"
 
 end


### PR DESCRIPTION
This change has a matching branch in ansible-dev HydraNorth.mysql.

```
hg clone https://code.library.ualberta.ca/hg/ansible-dev/
cd ansible-dev
hg checkout HydraNorth.mysql
```
- replaces sqlite with mysql
- playbook requires ansible-vault password (see PasswordSafe)
- hint: create a `.vault_pass.txt` containing just the password to continue using `vagrant up hydranorth`
