### PR TITLE
bump version of hydra-jetty

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Dependencies:
  * poppler
  * clamav
 * backing store
- * Solr 4.10.2
- * Fedora 4.0
+ * Solr 4.10.3
+ * Fedora 4.1 with authorization
  * MySQL
 
 To Install Application:

--- a/lib/tasks/jetty.rake
+++ b/lib/tasks/jetty.rake
@@ -1,2 +1,2 @@
 require 'jettywrapper'
-Jettywrapper.hydra_jetty_version = "v8.1.1"
+Jettywrapper.hydra_jetty_version = "v8.2.1"


### PR DESCRIPTION
To test this you'll need to replace your /var/www/sites/hydranorth/jetty dir:

```
rake jetty:stop # killall java
rake jetty:clean
rake sufia:jetty:config
rake jetty:start
```

This resets fedora and solr so all existing data would be lost.