### PR TITLE
non-admin users cannot destroy GenericFile fixes #33

### DIFF
--- a/app/views/my/_action_menu.html.erb
+++ b/app/views/my/_action_menu.html.erb
@@ -1,0 +1,36 @@
+<div class="btn-group">
+  <button class="btn btn-sm dropdown-toggle" data-toggle="dropdown" type="button" id="dropdownMenu_<%= id %>" aria-haspopup="true">
+    <span class="sr-only">Press to </span>
+    Select an action
+    <span class="caret" aria-hidden="true"></span>
+  </button>
+  <ul role="menu" class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenu_<%= id %>">
+    <li role="menuitem" tabindex="-1">
+    <%= link_to raw('<i class="glyphicon glyphicon-link over" aria-hidden="true"></i> Single-Use Link to File'), '#',
+      class: "copypaste itemicon itemcode", title: "Single-Use Link to File", id: "copy_link_#{id}" %>
+    </li>
+    <li role="menuitem" tabindex="-1">
+    <%= link_to raw('<i class="glyphicon glyphicon-pencil" aria-hidden="true"></i> Edit File'), sufia.edit_generic_file_path(id),
+      class: 'itemicon itemedit', title: 'Edit File' %>
+    </li>
+    <li role="menuitem" tabindex="-1">
+    <%= link_to raw('<i class="glyphicon glyphicon-download-alt" aria-hidden="true"></i> Download File'), sufia.download_path(id),
+      class: 'itemicon itemdownload', title: 'Download File', target: '_new' %>
+    </li>
+    <li role="menuitem" tabindex="-1">
+    <% if current_user.admin? %>
+      <%= link_to raw('<i class="glyphicon glyphicon-trash" aria-hidden="true"></i> Delete File'), sufia.generic_file_path(id),
+      class: 'itemicon itemtrash', title: 'Delete File', method: :delete, data: {
+      confirm: "Deleting a file from #{t('sufia.product_name')} is permanent. Click OK to delete this file from #{t('sufia.product_name')}, or Cancel to cancel this operation" } %>
+    <% end %>
+    </li>
+    <li role="menuitem" tabindex="-1">
+      <%= display_trophy_link(@user, id) do |text| %>
+        <i aria-hidden="true" class='glyphicon glyphicon-star'></i> <%= text %>
+      <% end %>
+    </li>
+    <li>
+      <%= link_to raw('<i class="glyphicon glyphicon-transfer" aria-hidden="true"></i> Transfer Ownership of File'), sufia.new_generic_file_transfer_path(id), class: 'itemicon itemtransfer', title: 'Transfer Ownership of File' if gf.depositor == @user.user_key %>
+    </li>
+  </ul>
+</div>

--- a/spec/features/admin_delete_spec.rb
+++ b/spec/features/admin_delete_spec.rb
@@ -43,10 +43,7 @@ describe 'delete', :type => :feature do
     end
 
     it "can't delete" do
-      select_delete file
-      expect(page).to have_content( "Not authorized to destroy generic file. Contact administrator for assistance." )
-      setup user
-      expect(page).to have_content( file.title.first )
+      expect { select_delete file }.to raise_error
     end
 
     it "doesn't see batch delete" do


### PR DESCRIPTION
also removed the batch delete button (batchuser can still delete)
also removed delete from action menu