### PR TITLE
fix for fickle test - do not recommend use of capybara's choose

### DIFF
--- a/spec/features/collection/collection_spec.rb
+++ b/spec/features/collection/collection_spec.rb
@@ -33,7 +33,8 @@ describe 'collection', :type => :feature do
       check "batch_document_#{collection.id}"
       click_button 'Add to Collection'
       expect(page).to have_content("Select the collection to add your files to:")
-      choose("id_#{community.id}", visible: false)
+      page.execute_script("document.getElementById('id_" + community.id + "').checked = true")
+      expect(find_field("id_#{community.id}")).to be_checked
       click_button 'Update Collection'
       expect(page).to have_content("Collection was successfully updated.")
       expect(page).to have_content(collection.title)


### PR DESCRIPTION
Think this will solve:
1) collection show collection as admin should allow me to nest collections
     Failure/Error: expect(page).to have_content("Is part of: #{community.title}")
       expected to find text "Is part of: Community" in "Hydra North click for notifications. click for admin@example.com dashboard Home About Help Contact Search Hydra North Go All × Collection was successfully updated. My DashboardMy Collections Theses Descriptions Total Items 0 Size 0 Bytes Actions Items in this Collection Search Collection Theses Go List of items in this collection Title Date Uploaded Visibility Action A service of Project Hydra. v.6.0.0.rc4 Copyright © 2015 Project Hydra Licensed under the Apache License, Version 2.0 Background image courtesy of Penn State University"
     # ./spec/features/collection/collection_spec.rb:40:in `block (3 levels) in <top (required)>'

Added another expected statement to check that the correct radio button is selected before submission so hopefully if this still occurs it will fail faster and more specifically

1) collection show collection as admin should allow me to nest collections
     Failure/Error: expect(find_field("id_#{community.id}")).to be_checked
       expected `#<Capybara::Element tag="input">.checked?` to return true, got false
     # ./spec/features/collection/collection_spec.rb:37:in `block (3 levels) in <top (required)>'
