### PR TITLE
Special report form

### DIFF
--- a/app/actors/hydranorth/generic_file/actor.rb
+++ b/app/actors/hydranorth/generic_file/actor.rb
@@ -15,6 +15,17 @@ module Hydranorth
         interpret_visibility
       end
 
+      def create_metadata_with_resource_type(batch_id, resource_type)
+
+        if resource_type
+          generic_file.resource_type = [resource_type]
+        else
+          ActiveFedora::Base.logger.warn "unable to find the resource type it sets to"
+        end
+
+        create_metadata(batch_id)
+      end
+
     end
   end
 end

--- a/app/controllers/concerns/hydranorth/batch_controller_behavior.rb
+++ b/app/controllers/concerns/hydranorth/batch_controller_behavior.rb
@@ -4,8 +4,56 @@ module Hydranorth
     include Sufia::BatchControllerBehavior
 
     included do 
-      class_attribute :edit_form_class
+      class_attribute :edit_form_class, :cstr_edit_form_class, :ser_edit_form_class
       self.edit_form_class = Hydranorth::Forms::BatchEditForm
+      self.cstr_edit_form_class = Hydranorth::Forms::CstrBatchEditForm
+      self.ser_edit_form_class = Hydranorth::Forms::SerBatchEditForm
+    end
+
+    def edit
+      @batch = Batch.find_or_create(params[:id])
+      @form = edit_form
+      @form[:resource_type] = @batch.generic_files.map(&:resource_type).flatten
+    end 
+    
+
+    def update
+      authenticate_user!
+      @batch = Batch.find_or_create(params[:id])
+      @batch.status = ["processing"]
+      @batch.save
+      resource_type = @batch.generic_files.map(&:resource_type).flatten
+      if resource_type.include? Sufia.config.special_reports['cstr']
+        @collection = Collection.find(Sufia.config.cstr_collection_id)
+      elsif resource_type.include? Sufia.config.special_reports['ser']
+        @collection = Collection.find(Sufia.config.ser_collection_id)
+      end
+      @batch.generic_files.each do |gf|
+        @collection.member_ids = @collection.member_ids.push(gf.id)
+        @collection.save
+      end
+      file_attributes = Hydranorth::Forms::BatchEditForm.model_attributes(params[:generic_file])
+      Sufia.queue.push(BatchUpdateJob.new(current_user.user_key, params[:id], params[:title], params[:trid], params[:ser], file_attributes, params[:visibility]))
+      flash[:notice] = 'Your files are being processed by ' + t('sufia.product_name') + ' in the background. The metadata and access controls you specified are being applied. Files will be marked <span class="label label-danger" title="Private">Private</span> until this process is complete (shouldn\'t take too long, hang in there!). You may need to refresh your dashboard to see these updates.'
+      if uploading_on_behalf_of? @batch
+        redirect_to sufia.dashboard_shares_path
+      else
+        redirect_to sufia.dashboard_files_path
+      end
+    end
+
+    protected
+    def edit_form
+      generic_file = ::GenericFile.new(creator: [current_user.name], title: @batch.generic_files.map(&:label))
+      resource_type = @batch.generic_files.map(&:resource_type).flatten
+      if resource_type.include? Sufia.config.special_reports['cstr']
+        cstr_edit_form_class.new(generic_file)
+      elsif resource_type.include? Sufia.config.special_reports['ser']
+        ser_edit_form_class.new(generic_file)
+      else
+        edit_form_class.new(generic_file)
+      end
+
     end
 
 

--- a/app/controllers/concerns/hydranorth/batch_controller_behavior.rb
+++ b/app/controllers/concerns/hydranorth/batch_controller_behavior.rb
@@ -25,12 +25,10 @@ module Hydranorth
       resource_type = @batch.generic_files.map(&:resource_type).flatten
       if resource_type.include? Sufia.config.special_reports['cstr']
         @collection = Collection.find(Sufia.config.cstr_collection_id)
+        add_to_collection
       elsif resource_type.include? Sufia.config.special_reports['ser']
         @collection = Collection.find(Sufia.config.ser_collection_id)
-      end
-      @batch.generic_files.each do |gf|
-        @collection.member_ids = @collection.member_ids.push(gf.id)
-        @collection.save
+        add_to_collection
       end
       file_attributes = Hydranorth::Forms::BatchEditForm.model_attributes(params[:generic_file])
       Sufia.queue.push(BatchUpdateJob.new(current_user.user_key, params[:id], params[:title], params[:trid], params[:ser], file_attributes, params[:visibility]))
@@ -43,6 +41,13 @@ module Hydranorth
     end
 
     protected
+    def add_to_collection
+      @batch.generic_files.each do |gf|
+      @collection.member_ids = @collection.member_ids.push(gf.id)
+      @collection.save
+    end
+ 
+    end
     def edit_form
       generic_file = ::GenericFile.new(creator: [current_user.name], title: @batch.generic_files.map(&:label))
       resource_type = @batch.generic_files.map(&:resource_type).flatten

--- a/app/controllers/concerns/hydranorth/batch_edits_controller_behavior.rb
+++ b/app/controllers/concerns/hydranorth/batch_edits_controller_behavior.rb
@@ -11,6 +11,13 @@ module Hydranorth
         redirect_to sufia.dashboard_index_path
       end
     end
+    protected
+    def terms
+      Hydranorth::Forms::BatchEditForm.terms
+    end
+    def generic_file_params
+      Hydranorth::Forms::BatchEditForm.model_attributes(params[:generic_file])
+    end
 
   end
 end

--- a/app/controllers/concerns/hydranorth/files_controller_behavior.rb
+++ b/app/controllers/concerns/hydranorth/files_controller_behavior.rb
@@ -43,6 +43,9 @@ module Hydranorth
       end
     end
     def process_file(file)
+
+      Batch.find_or_create(params[:batch_id])
+
       update_metadata_from_upload_screen
       update_resource_type_from_upload_screen
       if params[:resource_type].present?
@@ -50,7 +53,7 @@ module Hydranorth
       else
          actor.create_metadata(params[:batch_id])
       end
-      if actor.create_content(file, file.original_filename, datastream_id)
+      if actor.create_content(file, file.original_filename, file_path, file.content_type)
         respond_to do |format|
           format.html {
             render 'jq_upload', formats: 'json', content_type: 'text/html'

--- a/app/controllers/concerns/hydranorth/files_controller_behavior.rb
+++ b/app/controllers/concerns/hydranorth/files_controller_behavior.rb
@@ -21,7 +21,55 @@ module Hydranorth
       attributes = params
     end
 
+    def presenter
+     
+      if @generic_file[:resource_type].include? Sufia.config.special_reports['cstr'] 
+        Hydranorth::CstrPresenter.new(@generic_file)
+      elsif @generic_file[:resource_type].include? Sufia.config.special_reports['ser']
+        Hydranorth::SerPresenter.new(@generic_file)
+      else
+        Hydranorth::GenericFilePresenter.new(@generic_file)
+      end
+    end
 
+    def edit_form
+       
+      if @generic_file[:resource_type].include? Sufia.config.special_reports['cstr']
+        Hydranorth::Forms::CstrEditForm.new(@generic_file) 
+      elsif @generic_file[:resource_type].include? Sufia.config.special_reports['ser']
+        Hydranorth::Forms::SerEditForm.new(@generic_file)
+      else
+        Hydranorth::Forms::GenericFileEditForm.new(@generic_file)
+      end
+    end
+    def process_file(file)
+      update_metadata_from_upload_screen
+      update_resource_type_from_upload_screen
+      if params[:resource_type].present?
+         actor.create_metadata_with_resource_type(params[:batch_id], params[:resource_type]) 
+      else
+         actor.create_metadata(params[:batch_id])
+      end
+      if actor.create_content(file, file.original_filename, datastream_id)
+        respond_to do |format|
+          format.html {
+            render 'jq_upload', formats: 'json', content_type: 'text/html'
+          }
+          format.json {
+            render 'jq_upload'
+          }
+        end
+      else
+        msg = @generic_file.errors.full_messages.join(', ')
+        flash[:error] = msg
+        json_error "Error creating generic file: #{msg}"
+      end
+    end
+    def update_resource_type_from_upload_screen
+      # Relative path is set by the jquery uploader when uploading a directory
+      @generic_file.resource_type = [Sufia.config.special_reports['cstr']] if params[:resource_type] == Sufia.config.special_reports['cstr'] 
+      @generic_file.resource_type = [Sufia.config.special_reports['ser']] if params[:resource_type] == Sufia.config.special_reports['ser'] 
+    end
   end
 
 end

--- a/app/forms/hydranorth/forms/cstr_batch_edit_form.rb
+++ b/app/forms/hydranorth/forms/cstr_batch_edit_form.rb
@@ -1,0 +1,6 @@
+module Hydranorth
+  module Forms
+    class CstrBatchEditForm < CstrEditForm
+    end
+  end
+end

--- a/app/forms/hydranorth/forms/cstr_edit_form.rb
+++ b/app/forms/hydranorth/forms/cstr_edit_form.rb
@@ -1,0 +1,16 @@
+module Hydranorth
+  module Forms
+    class CstrEditForm < CstrPresenter
+      include HydraEditor::Form
+      self.required_fields = [:title, :creator, :subject, :license, :trid, :language]
+
+      # This is required so that fields_for will draw a nested form.
+      # See ActionView::Helpers#nested_attributes_association?
+      #   https://github.com/rails/rails/blob/a04c0619617118433db6e01b67d5d082eaaa0189/actionview/lib/action_view/helpers/form_helper.rb#L1890
+      def permissions_attributes= attributes
+        model.permissions_attributes= attributes
+      end
+
+    end
+  end
+end

--- a/app/forms/hydranorth/forms/ser_batch_edit_form.rb
+++ b/app/forms/hydranorth/forms/ser_batch_edit_form.rb
@@ -1,0 +1,6 @@
+module Hydranorth
+  module Forms
+    class SerBatchEditForm < SerEditForm
+    end
+  end
+end

--- a/app/forms/hydranorth/forms/ser_edit_form.rb
+++ b/app/forms/hydranorth/forms/ser_edit_form.rb
@@ -1,0 +1,16 @@
+module Hydranorth
+  module Forms
+    class SerEditForm < SerPresenter
+      include HydraEditor::Form
+      self.required_fields = [:title, :creator, :subject, :license, :ser, :language]
+
+      # This is required so that fields_for will draw a nested form.
+      # See ActionView::Helpers#nested_attributes_association?
+      #   https://github.com/rails/rails/blob/a04c0619617118433db6e01b67d5d082eaaa0189/actionview/lib/action_view/helpers/form_helper.rb#L1890
+      def permissions_attributes= attributes
+        model.permissions_attributes= attributes
+      end
+
+    end
+  end
+end

--- a/app/jobs/batch_update_job.rb
+++ b/app/jobs/batch_update_job.rb
@@ -1,0 +1,74 @@
+class BatchUpdateJob
+  include Hydra::PermissionsQuery
+  include Sufia::Messages
+
+  def queue_name
+    :batch_update
+  end
+
+  attr_accessor :login, :title, :trid, :ser, :file_attributes, :batch_id, :visibility, :saved, :denied
+
+  def initialize(login, batch_id, title, trid, ser, file_attributes, visibility)
+    self.login = login
+    self.title = title || {}
+    self.trid = trid if trid.present?
+    self.ser = ser if ser.present?
+    self.file_attributes = file_attributes
+    self.visibility = visibility
+    self.batch_id = batch_id
+    self.saved = []
+    self.denied = []
+  end
+
+  def run
+    batch = Batch.find_or_create(self.batch_id)
+    user = User.find_by_user_key(self.login)
+    batch.generic_files.each do |gf|
+      update_file(gf, user)
+    end
+
+    batch.update(status: ["Complete"])
+
+    if denied.empty?
+      send_user_success_message(user, batch) unless saved.empty?
+    else
+      send_user_failure_message(user, batch)
+    end
+  end
+
+  def update_file(gf, user)
+    unless user.can? :edit, gf
+      ActiveFedora::Base.logger.error "User #{user.user_key} DENIED access to #{gf.id}!"
+      denied << gf
+      return
+    end
+    gf.title = title[gf.id] if title[gf.id]
+    gf.attributes = file_attributes
+    gf.trid = trid[gf.id] if (trid.present? && trid[gf.id])
+    gf.ser = ser[gf.id] if (ser.present? && ser[gf.id])
+    gf.visibility= visibility
+    save_tries = 0
+    begin
+      gf.save!
+    rescue RSolr::Error::Http => error
+      save_tries += 1
+      ActiveFedora::Base.logger.warn "BatchUpdateJob caught RSOLR error on #{gf.id}: #{error.inspect}"
+      # fail for good if the tries is greater than 3
+      raise error if save_tries >=3
+      sleep 0.01
+      retry
+    end #
+    Sufia.queue.push(ContentUpdateEventJob.new(gf.id, login))
+    saved << gf
+  end
+
+  def send_user_success_message user, batch
+    message = saved.count > 1 ? multiple_success(batch.id, saved) : single_success(batch.id, saved.first)
+    User.batchuser.send_message(user, message, success_subject, sanitize_text = false)
+  end
+
+  def send_user_failure_message user, batch
+    message = denied.count > 1 ? multiple_failure(batch.id, denied) : single_failure(batch.id, denied.first)
+    User.batchuser.send_message(user, message, failure_subject, sanitize_text = false)
+  end
+end

--- a/app/jobs/batch_update_job.rb
+++ b/app/jobs/batch_update_job.rb
@@ -11,8 +11,11 @@ class BatchUpdateJob
   def initialize(login, batch_id, title, trid, ser, file_attributes, visibility)
     self.login = login
     self.title = title || {}
-    self.trid = trid if trid.present?
-    self.ser = ser if ser.present?
+    if trid.present?
+      self.trid = trid
+    elsif ser.present?
+      self.ser = ser
+    end
     self.file_attributes = file_attributes
     self.visibility = visibility
     self.batch_id = batch_id
@@ -44,8 +47,11 @@ class BatchUpdateJob
     end
     gf.title = title[gf.id] if title[gf.id]
     gf.attributes = file_attributes
-    gf.trid = trid[gf.id] if (trid.present? && trid[gf.id])
-    gf.ser = ser[gf.id] if (ser.present? && ser[gf.id])
+    if (trid.present? && trid[gf.id])
+      gf.trid = trid[gf.id]
+    elsif (ser.present? && ser[gf.id])
+      gf.ser = ser[gf.id]
+    end
     gf.visibility= visibility
     save_tries = 0
     begin

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -21,6 +21,7 @@ class Collection < Sufia::Collection
 
   def processing?
     false
+  end
 
   def self.find_or_create_with_type(resource_type) 
     cols = []

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -21,6 +21,22 @@ class Collection < Sufia::Collection
 
   def processing?
     false
+
+  def self.find_or_create_with_type(resource_type) 
+    cols = []
+    Collection.all.each do |c| 
+      cols << c if c[:resource_type].include? resource_type 
+    end
+    begin 
+      case cols.length.to_s
+      when "1"
+        cols.first
+      when "0" 
+        Collection.new(title: resource_type + " Collection", resource_type: [resource_type])
+      else
+        raise "More than one #{resource_type} collection exists."
+      end
+    end
   end
  
   # Compute the sum of each file in the collection

--- a/app/presenters/hydranorth/cstr_presenter.rb
+++ b/app/presenters/hydranorth/cstr_presenter.rb
@@ -1,0 +1,9 @@
+module Hydranorth
+  class CstrPresenter < GenericFilePresenter
+    include Hydra::Presenter
+    self.model_class = ::GenericFile
+    # Terms is the list of fields displayed by app/views/generic_files/_show_descriptions.html.erb
+    self.terms = [:resource_type, :title, :trid, :creator, :contributor, :description, :date_created, :license, :subject, :spatial, :temporal, :is_version_of, :source, :related_url, :language]
+
+  end
+end

--- a/app/presenters/hydranorth/ser_presenter.rb
+++ b/app/presenters/hydranorth/ser_presenter.rb
@@ -1,0 +1,9 @@
+module Hydranorth
+  class SerPresenter < GenericFilePresenter
+    include Hydra::Presenter
+    self.model_class = ::GenericFile
+    # Terms is the list of fields displayed by app/views/generic_files/_show_descriptions.html.erb
+    self.terms = [:resource_type, :title, :ser, :creator, :contributor, :description, :date_created, :license, :subject, :spatial, :temporal, :is_version_of, :source, :related_url, :language]
+
+  end
+end

--- a/app/views/batch/_metadata.html.erb
+++ b/app/views/batch/_metadata.html.erb
@@ -10,19 +10,14 @@
           <div id="additional_title_clone">
             <%= f.text_field :title, name: "title[#{gen_f.id}][]", value: gen_f.label, class: 'form-control', required: true %>
           </div>
-           <% if @form[:resource_type].include? Sufia.config.special_reports['cstr'] %>
-
-
-            <%= f.input_label :trid, as: :multi_value_with_help, label: "Computing Science Technical Report ID #{index + 1}" %>
-            <div id="additional_title_clone">
-              <%= f.text_field :trid, name: "trid[#{gen_f.id}][]", class: 'form-control', required: true %>
-            </div>
+          <% if @form[:resource_type].include? Sufia.config.special_reports['cstr'] %>
+            <%= f.input_label :trid, as: :single_field_with_help, label: "Computing Science Technical Report ID #{index + 1}" %>
+            <%= f.text_field :trid, name: "trid[#{gen_f.id}]", class: 'form-control', required: true %>
           <% end %>
           <% if @form[:resource_type].include? Sufia.config.special_reports['ser'] %>
-            <%= f.input_label :ser, as: :multi_value_with_help, label: "Structural Engineering Report Number #{index + 1}" %>
-            <div id="additional_title_clone">
-              <%= f.text_field :ser, name: "ser[#{gen_f.id}][]", class: 'form-control', required: true %>
-            </div>
+            <%= f.input_label :ser, as: :single_field_with_help, label: "Structural Engineering Report Number #{index + 1}" %>
+            <%= f.text_field :ser, name: "ser[#{gen_f.id}]", class: 'form-control', required: true %>
+          <% end %>
         </div>
       <% end %>
     </div>
@@ -40,8 +35,11 @@
     <div class="row">
       <div class="col-sm-6">
       <h3>Applies to all files just uploaded</h3>
-      <%= f.input :resource_type, as: :select_with_help, collection: Sufia.config.resource_types,
+      <% if (@form[:resource_type].include? Sufia.config.special_reports['cstr']) || (@form[:resource_type].include? Sufia.config.special_reports['ser']) %>
+      <% else %>
+        <%= f.input :resource_type, as: :select_with_help, collection: Sufia.config.resource_types,
           input_html: { class: 'form-control', multiple: true, required: true } %>
+      <% end %>
       <%= f.input :language, as: :select_with_help, collection: Sufia.config.languages, input_html: { class: 'form-control', required: true} %>
       <%= f.input :creator, as: :multi_value_with_help, input_html: { required: true } %>
       <%= f.input :subject, as: :multi_value_with_help, input_html: {required: true} %>

--- a/app/views/batch/_metadata.html.erb
+++ b/app/views/batch/_metadata.html.erb
@@ -10,6 +10,19 @@
           <div id="additional_title_clone">
             <%= f.text_field :title, name: "title[#{gen_f.id}][]", value: gen_f.label, class: 'form-control', required: true %>
           </div>
+           <% if @form[:resource_type].include? Sufia.config.special_reports['cstr'] %>
+
+
+            <%= f.input_label :trid, as: :multi_value_with_help, label: "Computing Science Technical Report ID #{index + 1}" %>
+            <div id="additional_title_clone">
+              <%= f.text_field :trid, name: "trid[#{gen_f.id}][]", class: 'form-control', required: true %>
+            </div>
+          <% end %>
+          <% if @form[:resource_type].include? Sufia.config.special_reports['ser'] %>
+            <%= f.input_label :ser, as: :multi_value_with_help, label: "Structural Engineering Report Number #{index + 1}" %>
+            <div id="additional_title_clone">
+              <%= f.text_field :ser, name: "ser[#{gen_f.id}][]", class: 'form-control', required: true %>
+            </div>
         </div>
       <% end %>
     </div>

--- a/app/views/batch/_more_metadata.html.erb
+++ b/app/views/batch/_more_metadata.html.erb
@@ -1,6 +1,6 @@
 <div id="more_descriptions">
   <button id="hide_addl_descriptions" class="btn btn-default" aria-label="hide additional metadata description fields">Hide Additional Fields</button>
-  <% (f.object.terms - [:title, :creator, :license, :resource_type, :language, :subject]).each do |term| %>
+  <% (f.object.terms - [:title, :trid, :ser, :creator, :license, :resource_type, :language, :subject]).each do |term| %>
     <%# <%= f.input term, as: :multi_value_with_help, input_html: { required: false} %>
     <%= render_edit_field_partial(term, f: f) %>
   <% end %>

--- a/app/views/generic_files/upload/_form.html.erb
+++ b/app/views/generic_files/upload/_form.html.erb
@@ -1,0 +1,12 @@
+<%= form_for(@generic_file, url: sufia.generic_files_path, html: { multipart: true, id: 'fileupload' }) do |f| %>
+  <% unless current_user.can_make_deposits_for.empty? %>
+    <div class="controls">
+      <%= label_tag :on_behalf_of, 'On Behalf of' %>
+      <%= select_tag :on_behalf_of, options_for_select(current_user.can_make_deposits_for), prompt: "Yourself" %>
+    </div>
+  <% end %>
+  <div class="well">
+    <%= render partial: 'generic_files/upload/special_reports' %>
+    <%= render partial: 'generic_files/upload/form_fields' %>
+  </div>
+<% end %>

--- a/app/views/generic_files/upload/_special_reports.html.erb
+++ b/app/views/generic_files/upload/_special_reports.html.erb
@@ -1,0 +1,8 @@
+<div class="controls">
+  <%= label_tag :special_reports, 'Uploading Special Reports?' %>
+  <%= radio_button_tag :resource_type, 'Computing Science Technical Report' %>
+  <%= label_tag :resource_type, 'Computing Science Technical Report' %>
+  <%= radio_button_tag :resource_type, 'Structural Engineering Report' %>
+  <%= label_tag :resource_type, 'Structural Engineering Report' %>
+  <%= button_tag "Reset", type: :reset %>  
+</div>

--- a/app/views/generic_files/upload/_special_reports.html.erb
+++ b/app/views/generic_files/upload/_special_reports.html.erb
@@ -4,5 +4,6 @@
   <%= label_tag :resource_type, 'Computing Science Technical Report' %>
   <%= radio_button_tag :resource_type, 'Structural Engineering Report' %>
   <%= label_tag :resource_type, 'Structural Engineering Report' %>
-  <%= button_tag "Reset", type: :reset %>  
+  <%= button_tag "Clear", class: 'btn btn-warning cancel reset-special-reports', id: 'reset-special-reports', name: "reset-special-reports", onclick: "confirmation_needed = false;", type: :reset %>  
+
 </div>

--- a/app/views/records/edit_fields/_resource_type.html.erb
+++ b/app/views/records/edit_fields/_resource_type.html.erb
@@ -1,0 +1,6 @@
+<% if (@form[:resource_type].include? Sufia.config.special_reports['cstr']) || (@form[:resource_type].include? Sufia.config.special_reports['ser']) %>
+  <% else %>
+
+    <%= f.input :resource_type, as: :select_with_help, collection: Sufia.config.resource_types,
+    input_html: { class: 'form-control', multiple: true } %>
+<% end %>

--- a/config/initializers/sufia.rb
+++ b/config/initializers/sufia.rb
@@ -68,7 +68,14 @@ Sufia.config do |config|
     "Other" => "other",
   }
 
+  config.cstr_collection_id = "6q182p35f"
+  config.ser_collection_id = "6q182p36q"
 
+  config.special_reports = {
+    "cstr" => "Computing Science Technical Report",
+    "ser" => "Structural Engineering Report",
+  }
+ 
   config.permission_levels = {
     "Choose Access"=>"none",
     "View/Download" => "read",

--- a/config/initializers/sufia.rb
+++ b/config/initializers/sufia.rb
@@ -68,9 +68,12 @@ Sufia.config do |config|
     "Other" => "other",
   }
 
-  config.cstr_collection_id = "6q182p35f"
-  config.ser_collection_id = "6q182p36q"
-
+  # please run rake db:seed to create the collections and restart httpd. 
+  # The collection IDs will be added here
+  # In production it assumes that the collections will be available in the system at the time of deposit
+  # config.cstr_collection_id = ""
+  # config.ser_collection_id = ""
+ 
   config.special_reports = {
     "cstr" => "Computing Science Technical Report",
     "ser" => "Structural Engineering Report",

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -44,7 +44,6 @@ ser = Collection.find_or_create_with_type("Structural Engineering Report").tap d
 end
 ser.save!
 config = File.open("config/initializers/sufia.rb", &:read)
-config = config.gsub(/#?(config.cstr_collection_id = ")/, '\1'+cstr.id)
-config = config.gsub(/#?(config.ser_collection_id = ")/, '\1'+ser.id)
-puts config  
+config = config.gsub(/#?\s*(config.cstr_collection_id = ")/, '\1'+cstr.id)
+config = config.gsub(/#?\s*(config.ser_collection_id = ")/, '\1'+ser.id)
 File.write("config/initializers/sufia.rb", config)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,17 +6,45 @@
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
 
-admin = User.new({
+
+# HYDRANORTH - PLEASE NOTE:
+# When adding new initial data 
+# please make sure you use methods or conditions to avoid duplication of the data/record
+# as rake db:seed may be run after the initial setup
+
+
+if !User.find_by_user_key("dittest@ualberta.ca")
+
+  admin = User.new({
       :email => "dittest@ualberta.ca",
       :password => "password",
       :password_confirmation => "password",
       :group_list => "admin" # this is the important part
-    })
+    }) unless User.find_by_user_key("dittest@ualberta.ca")
 
-admin.skip_confirmation!
-admin.save!
+  admin.skip_confirmation!
+  admin.save!
+end
 
-theses = Collection.new(title: "Theses").tap do |c|
+# IDs of the collections created below will be added to config/initializers/sufia.rb
+# please restart httpd after rake db:seed
+
+theses = Collection.find_or_create_with_type("Thesis").tap do |c|
   c.apply_depositor_metadata("dittest@ualberta.ca")
 end
 theses.save!
+
+cstr = Collection.find_or_create_with_type("Computing Science Technical Report").tap do |c|
+  c.apply_depositor_metadata("dittest@ualberta.ca")
+end
+cstr.save!
+
+ser = Collection.find_or_create_with_type("Structural Engineering Report").tap do |c|
+  c.apply_depositor_metadata("dittest@ualberta.ca")
+end
+ser.save!
+config = File.open("config/initializers/sufia.rb", &:read)
+config = config.gsub(/#?(config.cstr_collection_id = ")/, '\1'+cstr.id)
+config = config.gsub(/#?(config.ser_collection_id = ")/, '\1'+ser.id)
+puts config  
+File.write("config/initializers/sufia.rb", config)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -43,7 +43,10 @@ ser = Collection.find_or_create_with_type("Structural Engineering Report").tap d
   c.apply_depositor_metadata("dittest@ualberta.ca")
 end
 ser.save!
-config = File.open("config/initializers/sufia.rb", &:read)
-config = config.gsub(/#?\s*(config.cstr_collection_id = ")/, '\1'+cstr.id)
-config = config.gsub(/#?\s*(config.ser_collection_id = ")/, '\1'+ser.id)
+config = File.read("config/initializers/sufia.rb", &:read)
+config = config.gsub(/^.*config\.cstr_collection_id.*$/, '')
+config = config.gsub(/^.*config\.ser_collection_id.*$/, '')
+config = config.gsub(/(^.*config\.special_reports.*$)/, '  config.cstr_collection_id = "'+cstr.id+'"'+"\n"+'\1')
+config = config.gsub(/(^.*config\.special_reports.*$)/, '  config.ser_collection_id = "'+ser.id+'"'+"\n"+'\1')
+
 File.write("config/initializers/sufia.rb", config)

--- a/spec-views/batch_upload_form_spec.rb
+++ b/spec-views/batch_upload_form_spec.rb
@@ -5,10 +5,13 @@ require "./spec-views/helper.rb"
 require "./spec-views/before.rb"
 require "./spec-views/after.rb"
 require "./spec-views/user.rb"
+require "./spec-views/upload.rb"
 include RSpec::Expectations
 
 include Before
 include After
+include User
+include Upload
 
 describe "Batch Upload Form" do
 
@@ -17,86 +20,31 @@ describe "Batch Upload Form" do
   teardown
 
   it "form is up and submission can complete" do 
-    @driver.get(@base_url + "/")
-    @driver.find_element(:link, "Login").click
-    verify { (@driver.current_url).should == @base_url+"/users/sign_in"}
-    @driver.find_element(:id, "user_email").clear
-    @driver.find_element(:id, "user_email").send_keys @properties['admin']['name'] 
-    @driver.find_element(:id, "user_password").clear
-    @driver.find_element(:id, "user_password").send_keys @properties['admin']['password']
-    @driver.find_element(:name, "commit").click
-    @driver.get(@base_url + "/")
-    @driver.find_element(:id, "contribute_link").click
-    verify { @driver.current_url.should == @base_url+"/files/new" }
-    @driver.find_element(:id, "browse_everything_link").click
-    @driver.find_element(:xpath, "//form[contains(@id, 'browse_everything_form')]//input[contains(@name, 'terms_of_service')]").click 
-    batch_id = @driver.find_element(:id, "batch_id").attribute('value') 
-    @driver.find_element(:id, "browse-btn").click
-    @driver.find_element(:xpath, "//table[@id='file-list']//a[contains(@href, '/browse/file_system/spec-views')]").click
-    @driver.find_element(:xpath, "//a[contains(@href, '/browse/file_system/spec-views/files')]").click
-    @driver.find_element(:xpath, "//a[contains(@href, '/browse/file_system/spec-views/files/test.txt')]").click
-    @driver.find_element(:class, "ev-submit").click 
+    login_as_admin 
+    get_to_batch_upload_page
+    batch_id = upload_file_browse_everything
     sleep 5
     @driver.find_element(:id, "submit-btn").click 
     verify { @driver.current_url.should include @base_url+"/batches/" + batch_id }
-    @driver.find_element(:id, "new_generic_file")
-    title = @driver.find_element(:id, "generic_file_title")
-    title.clear
-    title.send_keys("Test Doc from Selenium")
-    file_id = title.attribute('name').match(/title\[(.*)\]\[.*\]$/)[1]
-    select_type = @driver.find_element(:id, "generic_file_resource_type")
-    option = Selenium::WebDriver::Support::Select.new(select_type)
-    option.select_by(:text, "Research Material") 
-    select_language = @driver.find_element(:id, "generic_file_language")
-    option = Selenium::WebDriver::Support::Select.new(select_language)
-    option.select_by(:text, "English")
-    @driver.find_element(:id, "generic_file_subject").send_keys "Test Text"
-    select_license = @driver.find_element(:id, "generic_file_license")
-    option = Selenium::WebDriver::Support::Select.new(select_license) 
-    option.select_by(:text, "Public Domain Mark 1.0")
-    @driver.find_element(:id, "show_addl_descriptions").click
-    @driver.find_element(:id, "generic_file_contributor").send_keys @properties['user1']['name']
-    @driver.find_element(:id, "generic_file_description").send_keys "Test description for the test object"
-    @driver.find_element(:id, "generic_file_date_created").send_keys "2015/03/23"
-    @driver.find_element(:id, "generic_file_spatial").send_keys "Calgary, Alberta, Canada"
-    @driver.find_element(:id, "generic_file_temporal").send_keys "2015"
-    @driver.find_element(:id, "generic_file_source").send_keys "test source"
-    @driver.find_element(:id, "generic_file_related_url").send_keys "http://www.ualberta.ca"
-    @driver.find_element(:id, "visibility_open").click
+    file_id = fill_in_metadata
     @driver.find_element(:id, "upload_submit").click
     for i in 0..5
-      sleep 30
-      @driver.find_element(:id, "dashboard_sort_submit").click
+      sleep 60
+      @driver.navigate.refresh
       processing = @driver.find_element(:id, "permission_"+file_id)
       text = processing.find_element(:class, "label-success").text
-      break if text == "Open Access" 
+      break if text == "Open Access"
       puts "Resque job can't complete after 5 tries. Please check if Resque runs properly."
+
     end
 
     
     a_id = "src_copy_link"+file_id 
     @driver.find_element(:id, a_id).click
     verify {@driver.current_url.should include @base_url + "/files/"+file_id}
-    verify { (@driver.find_element(:id, "permission_"+file_id).text).should == "Open Access" }
-    verify { (@driver.find_element(:css, "dd").text).should == "Research Material" }
-    verify { (@driver.find_element(:css, "h1.visibility").text).should == "Test Doc from Selenium Open Access" }
-    verify { @driver.find_element(:xpath, "//span[@itemprop = 'creator']/span/a").text.should == @properties['admin']['name'] }
+    verify_generic_metadata(file_id)   
 
-    verify { @driver.find_element(:xpath, "//span[@itemprop = 'contributor']/span/a").text.should == @properties['user1']['name'] }
-    verify { @driver.find_element(:xpath, "//span[@itemprop = 'dateCreated']").text.should == "2015/03/23" }
-    verify { @driver.find_element(:xpath, "//span[contains(@itemprop, 'about')]/span/a").text.should == "Test Text" }
-    verify { (@driver.find_element(:link, "Public Domain Mark 1.0").text).should == "Public Domain Mark 1.0" }
-    verify { @driver.find_element(:xpath, "//span[contains(@itemprop, 'spatial')]").text.should == "Calgary, Alberta, Canada" }
-    verify { @driver.find_element(:xpath, "//span[contains(@itemprop, 'temporal')]").text.should == "2015" }
-    verify { @driver.find_element(:xpath, "//span[contains(@itemprop, 'source')]").text.should == "test source" }
-    verify { @driver.find_element(:xpath, "//div[@class = 'related_url']/a").text.should include "http://www.ualberta.ca" }
-    verify { @driver.find_element(:xpath, "//span[contains(@itemprop, 'inLanguage')]/a").text.should == "English" }
-    @driver.find_element(:link, "My Files").click
-    sleep 20
-    verify { @driver.current_url.should == @base_url + "/dashboard/files" }
-    @driver.find_element(:id, "batch_document_"+file_id).click
-    @driver.find_element(:xpath, "//input[contains(@value, 'Delete Selected')]").click
-    @driver.switch_to.alert.accept
+    delete_file(file_id)
   end
 
 end 

--- a/spec-views/special_reports_upload_form_spec.rb
+++ b/spec-views/special_reports_upload_form_spec.rb
@@ -1,0 +1,104 @@
+require "json"
+require "selenium-webdriver"
+require "rspec"
+require "./spec-views/helper.rb"
+require "./spec-views/before.rb"
+require "./spec-views/after.rb"
+require "./spec-views/user.rb"
+include RSpec::Expectations
+
+include Before
+include After
+
+describe "Special Report Batch Upload Form" do
+
+  setup
+
+  teardown
+
+  it "form is up and can upload a CS Technical Report" do 
+
+    @driver.get(@base_url + "/")
+    @driver.find_element(:link, "Login").click
+    verify { (@driver.current_url).should == @base_url+"/users/sign_in"}
+    @driver.find_element(:id, "user_email").clear
+    @driver.find_element(:id, "user_email").send_keys @properties['admin']['name'] 
+    @driver.find_element(:id, "user_password").clear
+    @driver.find_element(:id, "user_password").send_keys @properties['admin']['password']
+    @driver.find_element(:name, "commit").click
+    @driver.get(@base_url + "/")
+    @driver.find_element(:id, "contribute_link").click
+    verify { @driver.current_url.should == @base_url+"/files/new" }
+    @driver.find_element(:id, "browse_everything_link").click
+    @driver.find_element(:xpath, "//form[contains(@id, 'browse_everything_form')]//input[contains(@name, 'terms_of_service')]").click 
+    batch_id = @driver.find_element(:id, "batch_id").attribute('value') 
+    @driver.find_element(:id, "browse-btn").click
+    @driver.find_element(:xpath, "//table[@id='file-list']//a[contains(@href, '/browse/file_system/spec-views')]").click
+    @driver.find_element(:xpath, "//a[contains(@href, '/browse/file_system/spec-views/files')]").click
+    @driver.find_element(:xpath, "//a[contains(@href, '/browse/file_system/spec-views/files/test.txt')]").click
+    @driver.find_element(:class, "ev-submit").click 
+    sleep 5
+    @driver.find_element(:id, "submit-btn").click 
+    verify { @driver.current_url.should include @base_url+"/batches/" + batch_id }
+    @driver.find_element(:id, "new_generic_file")
+    title = @driver.find_element(:id, "generic_file_title")
+    title.clear
+    title.send_keys("Test Doc from Selenium")
+    file_id = title.attribute('name').match(/title\[(.*)\]\[.*\]$/)[1]
+    select_type = @driver.find_element(:id, "generic_file_resource_type")
+    option = Selenium::WebDriver::Support::Select.new(select_type)
+    option.select_by(:text, "Research Material") 
+    select_language = @driver.find_element(:id, "generic_file_language")
+    option = Selenium::WebDriver::Support::Select.new(select_language)
+    option.select_by(:text, "English")
+    @driver.find_element(:id, "generic_file_subject").send_keys "Test Text"
+    select_license = @driver.find_element(:id, "generic_file_license")
+    option = Selenium::WebDriver::Support::Select.new(select_license) 
+    option.select_by(:text, "Public Domain Mark 1.0")
+    @driver.find_element(:id, "show_addl_descriptions").click
+    @driver.find_element(:id, "generic_file_contributor").send_keys @properties['user1']['name']
+    @driver.find_element(:id, "generic_file_description").send_keys "Test description for the test object"
+    @driver.find_element(:id, "generic_file_date_created").send_keys "2015/03/23"
+    @driver.find_element(:id, "generic_file_spatial").send_keys "Calgary, Alberta, Canada"
+    @driver.find_element(:id, "generic_file_temporal").send_keys "2015"
+    @driver.find_element(:id, "generic_file_source").send_keys "test source"
+    @driver.find_element(:id, "generic_file_related_url").send_keys "http://www.ualberta.ca"
+    @driver.find_element(:id, "visibility_open").click
+    @driver.find_element(:id, "upload_submit").click
+    for i in 0..5
+      sleep 30
+      @driver.navigate.refresh
+      processing = @driver.find_element(:id, "permission_"+file_id)
+      text = processing.find_element(:class, "label-success").text
+      break if text == "Open Access" 
+      puts "Resque job can't complete after 5 tries. Please check if Resque runs properly."
+    end
+
+    
+    a_id = "src_copy_link"+file_id 
+    @driver.find_element(:id, a_id).click
+    verify {@driver.current_url.should include @base_url + "/files/"+file_id}
+    verify { (@driver.find_element(:id, "permission_"+file_id).text).should == "Open Access"}
+    verify { @driver.find_element(:xpath, "//th[contains(text(), 'Type of Item')]/parent::tr/td/a").text.should == "Research Material" }
+    verify { @driver.find_element(:xpath, "//th[contains(text(), 'Title')]/parent::tr/td/span").text.should == "Test Doc from Selenium" }
+    verify { @driver.find_element(:xpath, "//span[@itemprop = 'creator']/span/a").text.should == @properties['admin']['name'] }
+
+    verify { @driver.find_element(:xpath, "//span[@itemprop = 'contributor']/span/a").text.should == @properties['user1']['name'] }
+    verify { @driver.find_element(:xpath, "//span[@itemprop = 'description']").text.should == "Test description for the test object" }
+    verify { @driver.find_element(:xpath, "//span[@itemprop = 'dateCreated']").text.should == "2015/03/23" }
+    verify { @driver.find_element(:xpath, "//th[contains(text(), 'Choose a license')]/parent::tr/td/a").text.should == "Public Domain Mark 1.0" }
+    verify { @driver.find_element(:xpath, "//span[contains(@itemprop, 'about')]/span/a").text.should == "Test Text" }
+    verify { @driver.find_element(:xpath, "//span[contains(@itemprop, 'spatial')]").text.should == "Calgary, Alberta, Canada" }
+    verify { @driver.find_element(:xpath, "//span[contains(@itemprop, 'temporal')]").text.should == "2015" }
+    verify { @driver.find_element(:xpath, "//span[contains(@itemprop, 'source')]").text.should == "test source" }
+    verify { @driver.find_element(:xpath, "//div[@class = 'related_url']/a").text.should include "http://www.ualberta.ca" }
+    verify { @driver.find_element(:xpath, "//span[contains(@itemprop, 'inLanguage')]/a").text.should == "English" }
+    @driver.find_element(:link, "My Files").click
+    sleep 20
+    verify { @driver.current_url.should == @base_url + "/dashboard/files" }
+    @driver.find_element(:id, "batch_document_"+file_id).click
+    @driver.find_element(:xpath, "//input[contains(@value, 'Delete Selected')]").click
+    @driver.switch_to.alert.accept
+  end
+
+end 

--- a/spec-views/upload.rb
+++ b/spec-views/upload.rb
@@ -1,45 +1,22 @@
-require "json"
-require "selenium-webdriver"
-require "rspec"
-require "./spec-views/helper.rb"
-require "./spec-views/before.rb"
-require "./spec-views/after.rb"
-require "./spec-views/user.rb"
-include RSpec::Expectations
-
-include Before
-include After
-
-describe "Special Report Batch Upload Form" do
-
-  setup
-
-  teardown
-
-  it "form is up and can upload a CS Technical Report" do 
-
-    @driver.get(@base_url + "/")
-    @driver.find_element(:link, "Login").click
-    verify { (@driver.current_url).should == @base_url+"/users/sign_in"}
-    @driver.find_element(:id, "user_email").clear
-    @driver.find_element(:id, "user_email").send_keys @properties['admin']['name'] 
-    @driver.find_element(:id, "user_password").clear
-    @driver.find_element(:id, "user_password").send_keys @properties['admin']['password']
-    @driver.find_element(:name, "commit").click
+module Upload
+  def get_to_batch_upload_page
     @driver.get(@base_url + "/")
     @driver.find_element(:id, "contribute_link").click
     verify { @driver.current_url.should == @base_url+"/files/new" }
+  end
+
+  def upload_file_browse_everything
     @driver.find_element(:id, "browse_everything_link").click
-    @driver.find_element(:xpath, "//form[contains(@id, 'browse_everything_form')]//input[contains(@name, 'terms_of_service')]").click 
-    batch_id = @driver.find_element(:id, "batch_id").attribute('value') 
+    @driver.find_element(:xpath, "//form[contains(@id, 'browse_everything_form')]//input[contains(@name, 'terms_of_service')]").click
+    batch_id = @driver.find_element(:id, "batch_id").attribute('value')
     @driver.find_element(:id, "browse-btn").click
     @driver.find_element(:xpath, "//table[@id='file-list']//a[contains(@href, '/browse/file_system/spec-views')]").click
     @driver.find_element(:xpath, "//a[contains(@href, '/browse/file_system/spec-views/files')]").click
     @driver.find_element(:xpath, "//a[contains(@href, '/browse/file_system/spec-views/files/test.txt')]").click
-    @driver.find_element(:class, "ev-submit").click 
-    sleep 5
-    @driver.find_element(:id, "submit-btn").click 
-    verify { @driver.current_url.should include @base_url+"/batches/" + batch_id }
+    @driver.find_element(:class, "ev-submit").click
+    return batch_id
+  end
+  def fill_in_metadata
     @driver.find_element(:id, "new_generic_file")
     title = @driver.find_element(:id, "generic_file_title")
     title.clear
@@ -47,13 +24,13 @@ describe "Special Report Batch Upload Form" do
     file_id = title.attribute('name').match(/title\[(.*)\]\[.*\]$/)[1]
     select_type = @driver.find_element(:id, "generic_file_resource_type")
     option = Selenium::WebDriver::Support::Select.new(select_type)
-    option.select_by(:text, "Research Material") 
+    option.select_by(:text, "Research Material")
     select_language = @driver.find_element(:id, "generic_file_language")
     option = Selenium::WebDriver::Support::Select.new(select_language)
     option.select_by(:text, "English")
     @driver.find_element(:id, "generic_file_subject").send_keys "Test Text"
     select_license = @driver.find_element(:id, "generic_file_license")
-    option = Selenium::WebDriver::Support::Select.new(select_license) 
+    option = Selenium::WebDriver::Support::Select.new(select_license)
     option.select_by(:text, "Public Domain Mark 1.0")
     @driver.find_element(:id, "show_addl_descriptions").click
     @driver.find_element(:id, "generic_file_contributor").send_keys @properties['user1']['name']
@@ -64,41 +41,36 @@ describe "Special Report Batch Upload Form" do
     @driver.find_element(:id, "generic_file_source").send_keys "test source"
     @driver.find_element(:id, "generic_file_related_url").send_keys "http://www.ualberta.ca"
     @driver.find_element(:id, "visibility_open").click
-    @driver.find_element(:id, "upload_submit").click
-    for i in 0..5
-      sleep 30
-      @driver.navigate.refresh
-      processing = @driver.find_element(:id, "permission_"+file_id)
-      text = processing.find_element(:class, "label-success").text
-      break if text == "Open Access" 
-      puts "Resque job can't complete after 5 tries. Please check if Resque runs properly."
-    end
+    return file_id
+  end
 
-    
-    a_id = "src_copy_link"+file_id 
-    @driver.find_element(:id, a_id).click
-    verify {@driver.current_url.should include @base_url + "/files/"+file_id}
-    verify { (@driver.find_element(:id, "permission_"+file_id).text).should == "Open Access"}
-    verify { @driver.find_element(:xpath, "//th[contains(text(), 'Type of Item')]/parent::tr/td/a").text.should == "Research Material" }
-    verify { @driver.find_element(:xpath, "//th[contains(text(), 'Title')]/parent::tr/td/span").text.should == "Test Doc from Selenium" }
+
+  def verify_generic_metadata(file_id)
+
+    verify { (@driver.find_element(:id, "permission_"+file_id).text).should == "Open Access" }
+    verify { (@driver.find_element(:css, "dd").text).should == "Research Material" }
+    verify { (@driver.find_element(:css, "h1.visibility").text).should == "Test Doc from Selenium Open Access" }
     verify { @driver.find_element(:xpath, "//span[@itemprop = 'creator']/span/a").text.should == @properties['admin']['name'] }
 
     verify { @driver.find_element(:xpath, "//span[@itemprop = 'contributor']/span/a").text.should == @properties['user1']['name'] }
-    verify { @driver.find_element(:xpath, "//span[@itemprop = 'description']").text.should == "Test description for the test object" }
     verify { @driver.find_element(:xpath, "//span[@itemprop = 'dateCreated']").text.should == "2015/03/23" }
-    verify { @driver.find_element(:xpath, "//th[contains(text(), 'Choose a license')]/parent::tr/td/a").text.should == "Public Domain Mark 1.0" }
     verify { @driver.find_element(:xpath, "//span[contains(@itemprop, 'about')]/span/a").text.should == "Test Text" }
+    verify { (@driver.find_element(:link, "Public Domain Mark 1.0").text).should == "Public Domain Mark 1.0" }
     verify { @driver.find_element(:xpath, "//span[contains(@itemprop, 'spatial')]").text.should == "Calgary, Alberta, Canada" }
     verify { @driver.find_element(:xpath, "//span[contains(@itemprop, 'temporal')]").text.should == "2015" }
     verify { @driver.find_element(:xpath, "//span[contains(@itemprop, 'source')]").text.should == "test source" }
     verify { @driver.find_element(:xpath, "//div[@class = 'related_url']/a").text.should include "http://www.ualberta.ca" }
     verify { @driver.find_element(:xpath, "//span[contains(@itemprop, 'inLanguage')]/a").text.should == "English" }
+
+  end
+
+  def delete_file(file_id)
     @driver.find_element(:link, "My Files").click
     sleep 20
     verify { @driver.current_url.should == @base_url + "/dashboard/files" }
+
     @driver.find_element(:id, "batch_document_"+file_id).click
     @driver.find_element(:xpath, "//input[contains(@value, 'Delete Selected')]").click
     @driver.switch_to.alert.accept
   end
-
-end 
+end

--- a/spec-views/upload.rb
+++ b/spec-views/upload.rb
@@ -46,7 +46,6 @@ module Upload
 
 
   def verify_generic_metadata(file_id)
-<<<<<<< HEAD
 
     verify { (@driver.find_element(:id, "permission_"+file_id).text).should == "Open Access" }
     verify { (@driver.find_element(:css, "dd").text).should == "Research Material" }

--- a/spec-views/user.rb
+++ b/spec-views/user.rb
@@ -1,18 +1,19 @@
 module User
 
   def login_as_admin
-    login_as_user(@properties['admin_user']['name'],@properties['admin_user']['password'])
+    login_as_user(@properties['admin']['name'],@properties['admin']['password'])
   end
 
   def login_as_user(name, password)
     @driver.get(@base_url + "/")
-    @driver.find_element(:title, "Login").click
+    @driver.find_element(:link, "Login").click
     verify { (@driver.current_url).should == @base_url+"/users/sign_in"}
     @driver.find_element(:id, "user_email").clear
     @driver.find_element(:id, "user_email").send_keys name
     @driver.find_element(:id, "user_password").clear
     @driver.find_element(:id, "user_password").send_keys password
     @driver.find_element(:name, "commit").click
+
   end
 
   def verify_as_user(user)

--- a/spec/presenters/hydranorth/cstr_presenter.rb
+++ b/spec/presenters/hydranorth/cstr_presenter.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe Hydranorth::CstrPresenter do
+  describe ".terms" do
+    it "should return a list" do
+      expect(described_class.terms).to eq([:resource_type, :title, :trid, :creator, :contributor, :description, :date_created, :license, :subject, :spatial, :temporal, :is_version_of, :source, :related_url, :language])
+    end
+  end
+end
+  
+

--- a/spec/presenters/hydranorth/ser_presenter.rb
+++ b/spec/presenters/hydranorth/ser_presenter.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe Hydranorth::SerPresenter do
+  describe ".terms" do
+    it "should return a list" do
+      expect(described_class.terms).to eq([:resource_type, :title, :ser, :creator, :contributor, :description, :date_created, :license, :subject, :spatial, :temporal, :is_version_of, :source, :related_url, :language])
+    end
+  end
+end
+  
+


### PR DESCRIPTION
As part of #30 and #130. Related pull request #143, #156. 
- Added to batch_controller_behavior and file_controller_behavior to handle special report ids. 
  - deposited items will be added to the corresponding collections. It assumes the collections have already created in the system. Please add the collection ids to the config/initializer/sufia.rb. 
- Added presenters and forms for special reports
- Added selection of special reports on the upload form

These collections are initialized in seed.rb. 
Also added/changed the creation of existing data to avoid duplication if rerun rake db:seed.

Please restart httpd after rake db:seed, as it writes the collection ids to config/initializers/sufia.rb, and will need a restart to make the modification in effect.