### PR TITLE
add db config for travis or default mysql

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -6,7 +6,7 @@
 development:
   adapter: mysql2
   database: hydranorthdev
-  username:
+  username: root 
   password:
   pool: 5
   timeout: 5000
@@ -17,7 +17,7 @@ development:
 test:
   adapter: mysql2
   database: hydranorthtest
-  username:
+  username: root
   password:
   pool: 5
   timeout: 5000
@@ -25,7 +25,7 @@ test:
 production:
   adapter: mysql2
   database: hydranorthprod
-  username:
+  username: root
   password:
   pool: 5
   timeout: 5000


### PR DESCRIPTION
```Couldn't create database for {"adapter"=>"mysql2", "database"=>"hydranorthtest", "username"=>nil, "password"=>nil, "pool"=>5, "timeout"=>5000}, {:charset=>"utf8", :collation=>"utf8_unicode_ci"}```

http://docs.travis-ci.com/user/database-setup/#MySQL