### PR TITLE
clamav 'no supported database files found' failing travis builds for some workers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ services:
   - redis-server
 before_install:
   - sudo apt-get update
-  - sudo apt-get install libclamav6 libclamav-dev clamav clamav-data
+  - sudo apt-get install libclamav-dev clamav-freshclam
 before_script:
   - redis-cli info
   - bundle exec rake jetty:start


### PR DESCRIPTION
Not sure if this is the required fix.  
Suggested by https://github.com/psu-stewardship/scholarsphere/commit/3bd94a9233abe225de081cf8f0580e78f4238253

[clamav](https://wiki.archlinux.org/index.php/ClamAV#Error:_No_supported_database_files_found) suggests ```freshclam -v```