### PR TITLE
Local geoname authority database

### DIFF
--- a/app/assets/javascripts/hydranorth/edit_metadata.js
+++ b/app/assets/javascripts/hydranorth/edit_metadata.js
@@ -1,0 +1,53 @@
+Blacklight.onLoad(function() {
+  function get_autocomplete_opts(field) {
+    var autocomplete_opts = {
+      minLength: 2,
+      source: function( request, response ) {
+        $.getJSON( "/authorities/generic_files/" + field, {
+          q: request.term
+        }, response );
+      },
+      focus: function() {
+        // prevent value inserted on focus
+        return false;
+      },
+      complete: function(event) {
+        $('.ui-autocomplete-loading').removeClass("ui-autocomplete-loading");
+      }
+    };
+    return autocomplete_opts;
+  }
+
+  var autocomplete_vocab = new Object();
+  autocomplete_vocab.url_var = ['spatial'];   // the url variable to pass to determine the vocab to attach to
+  autocomplete_vocab.field_name = new Array(); // the form name to attach the event for autocomplete
+
+  // loop over the autocomplete fields and attach the
+  // events for autocomplete and create other array values for autocomplete
+  for (var i=0; i < autocomplete_vocab.url_var.length; i++) {
+    autocomplete_vocab.field_name.push('generic_file_' + autocomplete_vocab.url_var[i]);
+    // autocompletes
+    $("#" + autocomplete_vocab.field_name[i])
+        // don't navigate away from the field on tab when selecting an item
+        .bind( "keydown", function( event ) {
+            if ( event.keyCode === $.ui.keyCode.TAB &&
+                    $( this ).data( "autocomplete" ).menu.active ) {
+                event.preventDefault();
+            }
+        })
+        .autocomplete( get_autocomplete_opts(autocomplete_vocab.url_var[i]) );
+  }
+
+
+  // attach an auto complete based on the field
+  function setup_autocomplete(e, cloneElem) {
+    var $cloneElem = $(cloneElem);
+    // FIXME this code (comparing the id) depends on a bug. Each input has an id and the id is
+    // duplicated when you press the plus button. This is not valid html.
+    if ( (index = $.inArray($cloneElem.attr("id"), autocomplete_vocab.field_name)) != -1 ) {
+      $cloneElem.autocomplete(get_autocomplete_opts(autocomplete_vocab.url_var[index]));
+    }
+  }
+
+  $('.multi_value.form-group').manage_fields({add: setup_autocomplete});
+});

--- a/app/models/concerns/hydranorth/generic_file/metadata.rb
+++ b/app/models/concerns/hydranorth/generic_file/metadata.rb
@@ -1,5 +1,4 @@
 require "./lib/rdf_vocabularies/ualterms"
-require "./lib/rdf_vocabularies/ualterms"
 
 module Hydranorth 
   module GenericFile
@@ -52,27 +51,13 @@ module Hydranorth
         property :hasCollection, predicate: ::UALTerms.hasCollection do |index|
           index.as :symbol, :stored_searchable
         end
+
+        begin
+          LocalAuthority.register_vocabulary(self, "spatial", "geonames_cities")
+        rescue
+          puts "tables for vocabularies missing"
+        end
  
-        property :unicorn, predicate: ::UALTerms.unicorn, multiple: false do |index|
-          index.as :stored_searchable
-        end
-       
-        property :proquest, predicate: ::UALTerms.proquest, multiple: false do |index|
-          index.as :stored_searchable
-        end
-
-        property :fedora3uuid, predicate: ::UALTerms.fedora3uuid, multiple: false do |index|
-          index.as :stored_searchable
-        end
-
-        property :fedora3handle, predicate: ::UALTerms.fedora3handle, multiple: false do |index|
-          index.as :stored_searchable
-        end
-
-        property :ingestbatch, predicate: ::UALTerms.ingestbatch, multiple: false do |index|
-          index.as :stored_searchable
-        end
-
       end
 
     end

--- a/app/models/concerns/sufia/generic_file/metadata.rb
+++ b/app/models/concerns/sufia/generic_file/metadata.rb
@@ -69,14 +69,6 @@ module Sufia
           index.as :stored_searchable
         end
 
-        # TODO: Move this somewhere more appropriate
-        begin
-          LocalAuthority.register_vocabulary(self, "subject", "lc_subjects")
-          LocalAuthority.register_vocabulary(self, "language", "lexvo_languages")
-          LocalAuthority.register_vocabulary(self, "tag", "lc_genres")
-        rescue
-          puts "tables for vocabularies missing"
-        end
       end
 
     end

--- a/bin/reset-all
+++ b/bin/reset-all
@@ -7,6 +7,7 @@ redis-cli flushall
 # wait for jetty to be available on port 8983
 sleep 30
 bundle exec rake db:reset
+bundle exec rake hydranorth:harvest:geonames_cities
 service httpd restart
 # kill old resque workers
 kill -9 `ps aux | grep [r]esque | grep -v grep | cut -c 10-16`

--- a/lib/tasks/hydranorth.rake
+++ b/lib/tasks/hydranorth.rake
@@ -1,0 +1,203 @@
+# borrowed and developed based on psu-stewardship/scholarsphere/lib/tasks/scholarsphere.rake
+
+namespace :hydranorth do
+
+  def logger
+    Rails.logger
+  end
+
+  desc "Characterize all files"
+  task characterize: :environment do
+    # grab the first increment of document ids from solr
+
+   resp = ActiveFedora::SolrService.instance.conn.get "select",
+              params:{ fl:['id'], fq: "#{ Solrizer.solr_name("has_model", :symbol)}:GenericFile"}
+    puts resp
+    #get the totalNumber and the size of the current response
+    totalNum =  resp["response"]["numFound"]
+    idList = resp["response"]["docs"]
+    page = 1
+
+    #loop through each page appending the ids to the original list
+    while idList.length < totalNum
+       page += 1
+       resp = ActiveFedora::SolrService.instance.conn.get "select",
+                      params:{ fl:['id'], fq: "#{ Solrizer.solr_name("has_model", :symbol)}:GenericFile",
+                      page:page}
+       idList = idList + resp["response"]["docs"]
+       totalNum =  resp["response"]["numFound"]
+    end
+
+    # for each document in the database call characterize
+    idList.each { |o|  Sufia.queue.push(CharacterizeJob.new o["id"])}
+  end
+
+  desc "Re-solrize all objects"
+  task resolrize: :environment do
+    Sufia.queue.push(ResolrizeJob.new)
+  end
+
+  namespace :export do
+    desc "Dump metadata as RDF/XML for e.g. Summon integration"
+    task rdfxml: :environment do
+      raise "rake scholarsphere:export:rdfxml output=FILE" unless ENV['output']
+      export_file = ENV['output']
+      triples = RDF::Repository.new
+      rows = GenericFile.count
+      GenericFile.find(:all).each do |gf|
+        next unless gf.rightsMetadata.groups["public"] == "read" && gf.descMetadata.content
+        RDF::Reader.for(:ntriples).new(gf.descMetadata.content) do |reader|
+          reader.each_statement do |statement|
+            triples << statement
+          end
+        end
+      end
+      unless triples.empty?
+        RDF::Writer.for(:rdfxml).open(export_file) do |writer|
+          writer << triples
+        end
+      end
+    end
+  end
+
+  namespace :harvest do
+
+    desc "Harvest Geonames cities"
+    task geonames_cities: :environment do |cmd, args|
+      vocabs = ["/tmp/cities1000.txt"]
+      LocalAuthority.harvest_tsv(cmd.to_s.split(":").last, vocabs, prefix: 'http://sws.geonames.org/')
+    end
+  end
+
+  namespace "checksum" do
+    desc "Run a checksum on all the GenericFiles"
+    task "all"  => :environment do
+      errors =[]
+      GenericFile.all.each do |gf|
+        next unless gf.content.checksum.blank?
+        gf.content.checksumType="MD5"
+        if gf.content.checksum == gf.original_checksum[0]
+          gf.content.checksumType="SHA-1"
+          gf.save # to do update version committer to checksum
+        else
+          errors << gf
+        end
+      end
+      errors.each {|gf| puts "Invalid Checksum: #{gf.pid} new: #{gf.content.checksum} original: #{gf.original_checksum[0]} "}
+
+    end
+  end
+
+  desc "Generate thumbnails for ALL documents"
+  task "generate_thumbnails" => :environment do
+
+    solr = ActiveFedora::SolrService.instance.conn.get "select",
+                  params:{ fl:['id'], fq: "#{ Solrizer.solr_name("has_model", :symbol)}:GenericFile"}
+    total_docs = solr["response"]["numFound"]
+    logger.info "Total documents to process: #{total_docs}"
+    
+    total_processed = errors = page = 0
+    while total_processed < total_docs
+      page += 1
+      solr = ActiveFedora::SolrService.instance.conn.get "select",
+                                  params:{ fl:['id'], fq: "#{ Solrizer.solr_name("has_model", :symbol)}:GenericFile",
+                                  page: page}
+      total_docs = solr["response"]["numFound"]
+      docs = solr["response"]["docs"]
+      docs.each do |doc|
+        begin
+          id = doc["id"]
+          Sufia.queue.push(CreateDerivativesJob.new id)
+        rescue Exception => e  
+          errors += 1
+          logger.error "Error processing document: #{id}\r\n#{e.message}\r\n#{e.backtrace.inspect}"  
+        end
+      end
+      total_processed += docs.length
+      logger.info "Total documents queued: #{total_processed}"
+    end
+    logger.error("Total errors: #{errors}") if errors > 0
+
+  end
+
+  # Start date must be in format 'yyyy/MM/dd'
+  desc "Prints to stdout a list of failed jobs in resque"
+  task "get_failed_jobs", [:start_date, :details] => :environment do |cmd, args|
+    details = (args[:details] == "true") 
+    start_date = args[:start_date] || Date.today.to_s.gsub('-', '/')
+    log = ""
+    i = 0
+    puts "Getting failed jobs from: #{start_date}"
+    Resque::Failure.each do |i, job| 
+      i += 1 
+      job_failed_at = job["failed_at"]
+      if job_failed_at >= start_date
+        payload = job["payload"]
+        job_args64 = payload["args"]
+        job_args = Base64.decode64(job_args64[0])
+        prefix_at = job_args.index("scholarsphere:") 
+        if prefix_at == nil
+          log += "Unexpected job arguments found: #{job_args}\r\n"
+        else
+          sufix_at = job_args.index(":", prefix_at + 14)
+          pid = job_args[prefix_at, sufix_at-prefix_at-1].chomp
+          if details
+
+            exception = job["exception"]
+            error = job["error"]
+            backtrace = job["backtrace"][0]
+            log += "PID: #{pid}\r\n"
+            log += "Failed at: #{job_failed_at}\r\n"
+            log += "Exception: #{exception} - #{error}\r\n"
+            log += "Backtrace: #{backtrace}\r\n" 
+            begin
+              gf = GenericFile.find(pid)
+              log += "File name: #{gf[:filename]}\r\n"
+              log += "Mime type: #{gf[:mime_type]}\r\n"
+            rescue Exception => e  
+              log += "File name: (could not be determined)\r\n"
+            end
+            log += "---------------\r\n"
+          else
+            log += "#{pid}\r\n"
+          end
+        end
+        puts i if (i % 100) == 0
+      end
+    end
+
+    puts "Writting log..."
+    File.write('find_failed_jobs.log', log)
+    puts "Done."
+
+  end
+
+  desc "Create derivatives for the documents indicated in a file. Each line in the file must include a PID (e.g. scholarsphere:123xyz)"
+  task "generate_thumbnail", [:file_name] => :environment do |cmd, args|
+    file_name = args[:file_name]
+    abort "Must provide a file name to read the PIDs" if file_name == nil
+    puts "Processing file #{file_name}"
+    File.readlines(file_name).each do |line|
+      pid = line.chomp
+      unless pid.empty?
+        Sufia.queue.push(CreateDerivativesJob.new pid)
+        puts "Queued derivatives for PID: #{pid}"
+      end
+    end
+  end  
+
+  desc "Characterizes documents indicated in a file. Each line in the file must include a PID (e.g. scholarsphere:123xyz)"
+  task "characterize_some", [:file_name] => :environment do |cmd, args|
+    file_name = args[:file_name]
+    abort "Must provide a file name to read the PIDs" if file_name == nil
+    puts "Processing file #{file_name}"
+    File.readlines(file_name).each do |line|
+      pid = line.chomp
+      unless pid.empty?
+        Sufia.queue.push(CharacterizeJob.new pid)
+        puts "Queued characterization for PID: #{pid}"
+      end
+    end
+  end    
+
+end

--- a/lib/tasks/hydranorth.rake
+++ b/lib/tasks/hydranorth.rake
@@ -64,6 +64,8 @@ namespace :hydranorth do
 
     desc "Harvest Geonames cities"
     task geonames_cities: :environment do |cmd, args|
+      system "curl 'http://download.geonames.org/export/dump/cities1000.zip' -o '/tmp/cities1000.zip'"
+      system "unzip '/tmp/cities1000.zip'" 
       vocabs = ["/tmp/cities1000.txt"]
       LocalAuthority.harvest_tsv(cmd.to_s.split(":").last, vocabs, prefix: 'http://sws.geonames.org/')
     end

--- a/spec/fixtures/geonames.tsv
+++ b/spec/fixtures/geonames.tsv
@@ -1,0 +1,149 @@
+3369100	Clanwilliam	Clanwilliam	Clanwilliam,Clanwillian	-32.18173	18.89217	P	PPLA3	ZA		11	DC1	WC012		0		96	Africa/Johannesburg	2012-07-12
+3369129	Ceres	Ceres	Cerera,Ceres,Ð¦ÐµÑ€ÐµÑ€Ð°	-33.36889	19.31095	P	PPLA3	ZA		11	DC2	WC022		41596		457	Africa/Johannesburg	2012-07-12
+3369157	Cape Town	Cape Town	Altepetl In Cabo,Ar Chab,CPT,Cape Toun,Cape Town,Cidade do Cabo,Cita del Cap,Citati du Capu,Citati dÃ» Capu,Citta del Capo,Cittae do Capo,CittÃ  del Capo,CitÃ  del Cap,Ciuda del Cabu,Ciudad del Cabo,Ciudat do Cabo,CiudÃ¡ del Cabu,Ciutat del Cap,Civitas Capitis,El Cabo,Fokvaros,FokvÃ¡ros,Gorad Kejptaun,Hoefdaborg,Hovdastadur,HÃ¶fÃ°aborg,HÃ¸vdastaÃ°ur,IKapa,Kaapstad,Kaapsted,KaapstÃªd,Kab town,Kabe Urbe,Kaburbo,Kaepstad,Kapetown,Kapkaupunki,Kaplinn,Kapske Mesto,Kapske Misto,KapskÃ© Mesto,KapskÃ© MÄ›sto,Kapstad,Kapstaden,Kapstadt,Kapsztad,KapÃ©town,Keip Taoun,Keiptauna,Keiptaunas,Keiptauns,Kejptaun,Keyptaun,KeÃ½ptaun,Le Cap,Li Kap,Lo Cap,Lurmutur Hiria,LÃ© Cap,Sita del Cao,Sita del Cap,SitÃ  del Cao,SitÃ  dÃ«l Cap,Tref y Penrhyn,Yvy akua Tava,Yvy akua TÃ¡va,hao wang jiao zhen,iKapa,kai pu dui,kai pu dun,keipeutaun,kep taun,kep tavun,kepa ta'una,kepata'una,keputaun,khep thawn,kyb tawn,kÛp Ù¼awn,Ã‡ittÃ¦ do Capo,Ä€ltepÄ“tl In Cabo,ÎšÎ­Î¹Ï€ Î¤Î¬Î¿Ï…Î½,Ð“Ð¾Ñ€Ð°Ð´ ÐšÐµÐ¹Ð¿Ñ‚Ð°ÑžÐ½,ÐšÐ°Ð¿ÑÐºÐµ ÐœÑ–ÑÑ‚Ð¾,ÐšÐµÐ¹Ð¿Ñ‚Ð°ÑƒÐ½,ÐšÐµÑ˜Ð¿Ñ‚Ð°ÑƒÐ½,Õ”Õ¥ÕµÖƒÕ©Õ¡Õ¸Ö‚Õ¶,×§××¤×©×˜××˜,×§×™×™×¤×˜××•×Ÿ,ÙƒÙŠØ¨ ØªØ§ÙˆÙ†,Ú©ÛŒÙ¾ Ù¹Ø§Ø¤Ù†,Ú©ÛŒÙ¾â€ŒØªØ§ÙˆÙ†,Ú©ÛÙ¾ Ù¼Ø§ÙˆÙ†,Ú©Û•ÛŒÙ¾ ØªØ§ÙˆÙ†,à¤•à¥‡à¤ª à¤Ÿà¤¾à¤‰à¤¨,à¤•à¥‡à¤ªà¤Ÿà¤¾à¤‰à¤¨,à¦•à§‡à¦ª à¦Ÿà¦¾à¦‰à¦¨,à¨•à©‡à¨ªà¨Ÿà¨¾à¨Šà¨¨,àª•à«‡àªª àªŸàª¾àª‰àª¨,à¬•à­‡à¬ª à¬Ÿà¬¾à¬‰à¬¨,à®•à¯‡à®ªà¯ à®Ÿà®µà¯à®©à¯,à°•à±‡à°ªà± à°Ÿà±Œà°¨à±,à²•à³‡à²ªà³ à²Ÿà³Œà²¨à³,à´•àµ‡à´ªàµ à´Ÿàµ—àµº,à¹€à¸„à¸›à¸—à¸²à¸§à¸™à¹Œ,á€€á€­á€•á€ºá€á€±á€¬á€„á€ºá€¸á€™á€¼á€­á€¯á€·,áƒ™áƒ”áƒ˜áƒžáƒ¢áƒáƒ£áƒœáƒ˜,áŠ¬á• á‰³á‹áŠ•,ã‚±ãƒ¼ãƒ—ã‚¿ã‚¦ãƒ³,å¥½æœ›è§’éŽ®,é–‹æ™®æ•¦,ì¼€ì´í”„íƒ€ìš´	-33.92584	18.42322	P	PPLA	ZA		11	CPT	CPT		3433441		25	Africa/Johannesburg	2013-08-18
+3369174	Calvinia	Calvinia	Calvinia	-31.47069	19.77601	P	PPLA3	ZA		08	DC6	NC065		8146		987	Africa/Johannesburg	2012-07-12
+3369179	Caledon	Caledon	Caledon	-34.22997	19.4265	P	PPLA3	ZA		11	DC3	WC031		4687		260	Africa/Johannesburg	2012-07-12
+3370105	Bergvliet	Bergvliet	Bergvliet	-34.04746	18.4525	P	PPLX	ZA		11	CPT	CPT		3902		27	Africa/Johannesburg	2013-08-18
+3370352	Atlantis	Atlantis	Atlantida,Atlantis,ÐÑ‚Ð»Ð°Ð½Ñ‚Ð¸Ð´Ð°	-33.56668	18.48335	P	PPL	ZA		11	CPT	CPT		60266		178	Africa/Johannesburg	2012-07-12
+6942529	Sunset Beach	Sunset Beach		-33.85395	18.49231	P	PPL	ZA		11	CPT	CPT		2000	20	7	Africa/Johannesburg	2012-07-12
+7302802	Rondebosch	Rondebosch	Rondebosch	-33.96333	18.47639	P	PPL	ZA		11	CPT	CPT		15158		28	Africa/Johannesburg	2013-08-18
+7506857	Newlands	Newlands	Newlands	-33.97846	18.4481	P	PPL	ZA		11	CPT	CPT		5343		70	Africa/Johannesburg	2013-08-18
+7576313	Bela-Bela	Bela-Bela		-24.885	28.29417	P	PPLA3	ZA		09	DC36	LIM366		0		1130	Africa/Johannesburg	2012-07-12
+7730334	Lephalale	Lephalale	ELL,Ellisras,Lephalale	-23.66607	27.74477	P	PPLA3	ZA		09	DC36	LIM362		0		824	Africa/Johannesburg	2013-11-03
+8030223	Musina	Musina		-22.34881	30.04074	P	PPLA3	ZA		09	DC34	LIM341		0		540	Africa/Johannesburg	2012-07-12
+8063456	Mandeni	Mandeni		-29.14691	31.41403	P	PPLA3	ZA		02	DC29	KZN291		0		88	Africa/Johannesburg	2012-07-12
+8604596	Retreat	Retreat	Retreat	-34.05515	18.47617	P	PPL	ZA		11	CPT	CPT		32289		8	Africa/Johannesburg	2013-08-18
+8642862	Graksop	Graksop		-24.93174	30.84008	P	PPL	ZA		07	DC32	MP321		3996		1442	Africa/Johannesburg	2013-11-15
+8764562	Diepsloot	Diepsloot		-25.93312	28.01213	P	PPLX	ZA		06	JHB	JHB		350000		1410	Africa/Johannesburg	2014-04-08
+175499	Nchelenge	Nchelenge	Nchelenge,ÐÑ‡ÐµÐ»ÐµÐ½Ð³Ðµ	-9.34506	28.73396	P	PPL	ZM		04				23693		933	Africa/Lusaka	2012-01-17
+175555	Nakonde	Nakonde		-9.34213	32.745	P	PPL	ZM		05				10652		1589	Africa/Lusaka	2011-03-06
+175961	Mpulungu	Mpulungu	Mpolungu,Mpulungu	-8.76234	31.11405	P	PPL	ZM		05				8547		800	Africa/Lusaka	2012-04-23
+175967	Mporokoso	Mporokoso	Mpolokoso,Mporokoso	-9.37273	30.12501	P	PPL	ZM		05				3401		1442	Africa/Lusaka	2012-01-17
+176146	Mbala	Mbala	Abercorn,MMQ,Mbala,ÐœÐ±Ð°Ð»Ð°	-8.84024	31.36587	P	PPL	ZM		05				20570		1622	Africa/Lusaka	2012-01-17
+176555	Kawambwa	Kawambwa	Kawambwa,Kawamowa	-9.7915	29.07913	P	PPL	ZM		04				20589		1342	Africa/Lusaka	2012-01-17
+176758	Kaputa	Kaputa		-8.46887	29.66193	P	PPL	ZM		05				2683		950	Africa/Lusaka	2011-04-18
+895953	Zambezi	Zambezi	BBZ,Balovale,Rio Zambeze,Sambesi,SambesÃ­,Zambesi,Zambeze,Zambezi,ZambezÄ—,ZambÃ¨ze,ZambÃ©zi,zan bi xi he,zanbeji chuan,zmbzy,Ð—Ð°Ð¼Ð±ÐµÐ·Ð¸,Ð—Ð°Ð¼Ð±ÐµÐ·Ñ–,×–×ž×‘×–×™,ã‚¶ãƒ³ãƒ™ã‚¸å·,èµžæ¯”è¥¿æ²³	-13.54323	23.10467	P	PPL	ZM		06				7074		1079	Africa/Lusaka	2012-01-17
+897045	Solwezi	Solwezi	SLI,Solwezi	-12.1688	26.38938	P	PPLA	ZM		06				4846		1381	Africa/Lusaka	2012-01-17
+897456	Sinazongwe	Sinazongwe	Sinasongwe,Sinazongwe	-17.2614	27.46179	P	PPL	ZM		07				11528		504	Africa/Lusaka	2014-04-06
+898188	Siavonga	Siavonga	Chapvonga,Siavonga	-16.53818	28.70876	P	PPL	ZM		07				18638		528	Africa/Lusaka	2012-01-17
+898905	Sesheke	Sesheke	SJQ,Sesheke,Shesheke,Sisheke,Ð¨ÐµÑˆÐµÐºÐµ	-17.47593	24.29684	P	PPL	ZM		01				20149		951	Africa/Lusaka	2012-01-17
+898912	Serenje	Serenje	Serenje	-13.23251	30.23522	P	PPL	ZM		02				8779		1424	Africa/Lusaka	2012-01-17
+898947	Senanga	Senanga	SXG,Senanga,Sinanga	-16.11667	23.26667	P	PPL	ZM		01				10005		1001	Africa/Lusaka	2012-01-17
+899274	Samfya	Samfya	Samfya	-11.36491	29.55652	P	PPL	ZM		04				20470		1183	Africa/Lusaka	2012-01-17
+899825	Petauke	Petauke	Petauke	-14.24264	31.3253	P	PPL	ZM		03				19296		1021	Africa/Lusaka	2012-01-17
+900056	Nyimba	Nyimba		-14.55656	30.8149	P	PPL	ZM		03				1336		716	Africa/Lusaka	2011-03-06
+901344	Ndola	Ndola	NLA,Ndola,Ntola,en duo la,eundolla,ndola,ndora,ndwla,ÎÏ„ÏŒÎ»Î±,ÐÐ´Ð¾Ð»Ð°,Ù†Ø¯ÙˆÙ„Ø§,áƒœáƒ“áƒáƒšáƒ,ãƒ³ãƒ‰ãƒ©,æ©å¤šæ‹‰,ì€ëŒë¼	-12.95867	28.63659	P	PPLA	ZM		08				394518		1307	Africa/Lusaka	2012-01-17
+901766	Namwala	Namwala	Namwala	-15.75042	26.43839	P	PPL	ZM		07				4450		999	Africa/Lusaka	2012-01-17
+902344	Nakambala	Nakambala		-15.83244	27.77994	P	PPL	ZM		07				10425		1023	Africa/Lusaka	2011-03-06
+902620	Mwinilunga	Mwinilunga	Mwinilunga,Wwinilunga	-11.73584	24.42926	P	PPL	ZM		06				13798		1364	Africa/Lusaka	2012-01-17
+902721	Mwense	Mwense		-10.38447	28.698	P	PPL	ZM		04				4378		959	Africa/Lusaka	2011-03-06
+904241	Mungwi	Mungwi		-10.1732	31.36942	P	PPL	ZM		05				6821		1382	Africa/Lusaka	2011-03-06
+904422	Mumbwa	Mumbwa	Mumbwa	-14.98293	27.0619	P	PPL	ZM		02				19086		1185	Africa/Lusaka	2012-06-05
+905382	Mufumbwe	Mufumbwe		-13.68333	24.8	P	PPL	ZM		06				6155		1143	Africa/Lusaka	2006-01-17
+905395	Mufulira	Mufulira	Mufulira,Mufulire,ÐœÑƒÑ„ÑƒÐ»Ð¸Ñ€Ðµ	-12.54982	28.24071	P	PPL	ZM		08				120500		1285	Africa/Lusaka	2012-01-17
+905789	Mpongwe	Mpongwe		-13.50914	28.15504	P	PPL	ZM		08				8997		1195	Africa/Lusaka	2011-04-18
+905846	Mpika	Mpika	Mpika	-11.83431	31.45287	P	PPL	ZM		05				28445		1428	Africa/Lusaka	2012-01-17
+906044	Monze	Monze	Monze	-16.28333	27.48333	P	PPL	ZM		07				30257		1124	Africa/Lusaka	2012-01-17
+906054	Mongu	Mongu	MNR,Mongu,Mungu,ÐœÐ¾Ð½Ð³Ñƒ	-15.24835	23.12741	P	PPLA	ZM		01				52534		1016	Africa/Lusaka	2012-01-17
+906221	Mkushi	Mkushi	Mkushi	-13.62015	29.3939	P	PPL	ZM		02				12306		1257	Africa/Lusaka	2012-01-17
+907111	Mazabuka	Mazabuka	Mazabuka,ÐœÐ°Ð·Ð°Ð±ÑƒÐºÐ°	-15.85601	27.748	P	PPL	ZM		07				64006		1050	Africa/Lusaka	2012-01-17
+907770	Mansa	Mansa	Fort Rosebery,MNS,Mansa,Mbila,Roseberry,ÐœÐ°Ð½ÑÐ°	-11.19976	28.89431	P	PPLA	ZM		04				42277		1216	Africa/Lusaka	2012-01-17
+908718	Maamba	Maamba	Maamba	-17.36667	27.15	P	PPL	ZM		07				12251		754	Africa/Lusaka	2012-01-17
+908913	Luwingu	Luwingu	Luingu,Luwingo,Luwingu	-10.2621	29.92712	P	PPL	ZM		05				6161		1381	Africa/Lusaka	2012-01-17
+909137	Lusaka	Lusaka	Gorad Lusaka,LUN,Lousaka,Louzaka,Lusaca,Lusaka,Lusako,LÃºsaka,LÃ»saka,lu sa ka,lu sha ka,lucakka,lusaka,lwsaka,lwsqh,lwwsaka,rusaka,Î›Î¿Ï…ÏƒÎ¬ÎºÎ±,Ð“Ð¾Ñ€Ð°Ð´ Ð›ÑƒÑÐ°ÐºÐ°,Ð›ÑƒÑÐ°ÐºÐ°,Ô¼Õ¸Ö‚Õ½Õ¡Õ¯Õ¡,×œ×•×¡××§×,×œ×•×¡×§×”,Ù„ÙˆØ³Ø§ÙƒØ§,Ù„ÙˆØ³Ø§Ú©Ø§,Ù„ÙˆÙˆØ³Ø§Ú©Ø§,Ù„Û‡Ø³Ø§ÙƒØ§,à¤²à¥à¤¸à¤¾à¤•à¤¾,à¦²à§à¦¸à¦¾à¦•à¦¾,à¨²à©à¨¸à¨¾à¨•à¨¾,à¬²à­à¬¸à¬¾à¬•,à®²à¯à®šà®¾à®•à¯à®•à®¾,à¸¥à¸¹à¸‹à¸²à¸à¸²,à½£à½´à¼‹à½¦à¼‹à½€à¼,áƒšáƒ£áƒ¡áƒáƒ™áƒ,áˆ‰áˆ³áŠ«,ãƒ«ã‚µã‚«,ç›§è–©å¡,è·¯æ²™å¡,ë£¨ì‚¬ì¹´	-15.40669	28.28713	P	PPLC	ZM		09				1267440		1277	Africa/Lusaka	2011-10-27
+909299	Lundazi	Lundazi	Lundazi	-12.29292	33.1782	P	PPL	ZM		03				11635		1143	Africa/Lusaka	2012-01-17
+909488	Lukulu	Lukulu	LXU,Lukulu	-14.37067	23.24196	P	PPL	ZM		01				3349		1048	Africa/Lusaka	2012-01-17
+909863	Luanshya	Luanshya	Luanshya,Luanshyo	-13.13667	28.41661	P	PPL	ZM		08				113365		1238	Africa/Lusaka	2012-01-17
+909887	Luangwa	Luangwa	Feira,Luangwa	-15.61667	30.41667	P	PPL	ZM		09				3065		328	Africa/Lusaka	2012-01-17
+910111	Livingstone	Livingstone	LVI,Livin'nkston,Livingston,Livingstonas,Livingstone,Livingstore,Livingstun,Maramba,li wen si dun,libingseuteon,lywwyngstwn,Î›Î¯Î²Î¹Î½Î³ÎºÏƒÏ„Î¿Î½,Ð›Ð¸Ð²Ð¸Ð½Ð³ÑÑ‚Ð¾Ð½,Ð›Ð¸Ð²Ð¸Ð½Ð³ÑÑ‚ÑŠÐ½,ÐœÐ°Ñ€Ð°Ð¼Ð±Ð°,×œ×™×•×•×™× ×’×¡×˜×•×Ÿ,åˆ©æ–‡æ–¯é¡¿,ë¦¬ë¹™ìŠ¤í„´	-17.84194	25.85425	P	PPLA	ZM		07				109203		969	Africa/Lusaka	2014-07-18
+910361	Limulunga	Limulunga	Limulunga	-15.09691	23.13757	P	PPL	ZM		01				7461		1023	Africa/Lusaka	2012-01-17
+911148	Kitwe	Kitwe	KIW,Kitoue,Kitue,Kitve,Kitve-Nkana,KitvÄ—,Kitwe,Kitwe Nkana,Nkana-Kitwe,ji te wei,kiteuwe,kitou~e,kytwy,ÎšÎ¯Ï„Î¿Ï…Îµ,ÐšÐ¸Ñ‚Ð²Ðµ,ÐšÐ¸Ñ‚Ð²Ðµ-ÐÐºÐ°Ð½Ð°,ÐšÐ¸Ñ‚ÑƒÐµ,Ô¿Õ«Õ¿Õ¾Õ¥-Õ†Õ¯Õ¡Õ¶Õ¡,ÙƒÙŠØªÙˆÙŠ,ã‚­ãƒˆã‚¦ã‚§,åŸºç‰¹éŸ¦,í‚¤íŠ¸ì›¨	-12.80243	28.21323	P	PPL	ZM		08				400914		1224	Africa/Lusaka	2012-06-20
+912226	Kataba	Kataba	Kataba	-11.88333	29.78333	P	PPL	ZM		08				14000		1163	Africa/Lusaka	2013-05-05
+912628	Kasempa	Kasempa	Kasama,Kasempa	-13.45836	25.8338	P	PPL	ZM		06				5622		1235	Africa/Lusaka	2012-01-17
+912764	Kasama	Kasama	Arcidiocesi di Kasama,KAA,Kasama,ÐšÐ°ÑÐ°Ð¼Ð°	-10.21289	31.18084	P	PPLA	ZM		05				91056		1394	Africa/Lusaka	2012-01-17
+913029	Kapiri Mposhi	Kapiri Mposhi	Kapiri Imposhi,Kapiri Mposhi	-13.97147	28.66985	P	PPL	ZM		02				37942		1265	Africa/Lusaka	2012-06-05
+913323	Kaoma	Kaoma	KMZ,Kaoma,Mankoya,Mankoye,Nankoya,Nunkoya	-14.78333	24.8	P	PPL	ZM		01				14212		1126	Africa/Lusaka	2012-01-17
+913613	Kansanshi	Kansanshi	Kansanshi,Kansanshi Mine,Kansenshi	-12.09514	26.42727	P	PPL	ZM		06				40705		1429	Africa/Lusaka	2011-10-27
+914959	Kalulushi	Kalulushi	Kalulshi,Kalulushi	-12.84151	28.09479	P	PPL	ZM		08				66575		1304	Africa/Lusaka	2012-06-20
+915285	Kalengwa	Kalengwa		-13.46586	25.00271	P	PPL	ZM		06				7574		1197	Africa/Lusaka	2011-03-06
+915471	Kalabo	Kalabo	KLB,Kalabo	-14.97005	22.68138	P	PPL	ZM		01				7731		1023	Africa/Lusaka	2012-02-01
+915883	Kafue	Kafue	Kafe,Kafue,ÐšÐ°Ñ„Ðµ	-15.76911	28.18136	P	PPL	ZM		09				47554		996	Africa/Lusaka	2012-01-17
+916095	Kabwe	Kabwe	Broken Hill,Gorad Kabveh,Kabue,Kabve,KabvÄ—,Kabwe,QKE,ka bu wei,kabeuwe,kabuu~e,kabwy,Ð“Ð¾Ñ€Ð°Ð´ ÐšÐ°Ð±Ð²Ñ,ÐšÐ°Ð±Ð²Ðµ,ÐšÐ°Ð±ÑƒÐµ,ÙƒØ§Ø¨ÙˆÙŠ,ã‚«ãƒ–ã‚¦ã‚§,å¡å¸ƒéŸ¦,ì¹´ë¸Œì›¨	-14.4469	28.44644	P	PPLA	ZM		02				188979		1191	Africa/Lusaka	2011-10-20
+916246	Kabompo	Kabompo	Kabompo	-13.59268	24.20081	P	PPL	ZM		06				6592		1113	Africa/Lusaka	2012-01-17
+916668	Isoka	Isoka	Isoka	-10.16062	32.63353	P	PPL	ZM		05				13122		1321	Africa/Lusaka	2012-01-17
+917011	Gwembe	Gwembe	Gwembe	-16.49755	27.60691	P	PPL	ZM		07				2052		1247	Africa/Lusaka	2012-01-17
+917688	Chongwe	Chongwe		-15.32916	28.68204	P	PPL	ZM		09				6057		1102	Africa/Lusaka	2011-03-06
+917748	Choma	Choma	Choma	-16.80648	26.95305	P	PPL	ZM		07				46746		1327	Africa/Lusaka	2012-01-17
+918702	Chipata	Chipata	CIP,Chipata,Cipata,Fort Jameson,Tsipata,chipata,qi pa ta,ÄŒipata,Î¤ÏƒÎ¹Ï€Î¬Ï„Î±,Ð§Ð¸Ð¿Ð°Ñ‚Ð°,å¥‡å¸•å¡”,ì¹˜íŒŒíƒ€	-13.63333	32.65	P	PPLA	ZM		03				85963		1147	Africa/Lusaka	2012-01-17
+918905	Chinsali	Chinsali	Chinsala,Chinsali	-10.54142	32.08162	P	PPL	ZM		05				14015		1286	Africa/Lusaka	2012-01-17
+919009	Chingola	Chingola	CGJ,Chingola,Ð§Ð¸Ð½Ð³Ð¾Ð»Ð°	-12.52897	27.88382	P	PPL	ZM		08				148564		1363	Africa/Lusaka	2012-01-17
+919544	Chililabombwe	Chililabombwe	Bancroft,Chilabombwe,Chiliabombwe,Chiliadomewe,Chililabombwe	-12.36475	27.82286	P	PPL	ZM		08				57328		1316	Africa/Lusaka	2012-01-17
+920233	Chibombo	Chibombo	Chibombo	-14.65685	28.07057	P	PPL	ZM		02				4477		1156	Africa/Lusaka	2014-03-03
+920820	Chambishi	Chambishi	Chambezi,Chambishi	-12.63247	28.05367	P	PPL	ZM		08				11073		1304	Africa/Lusaka	2011-10-20
+920901	Chama	Chama	Chama	-11.21303	33.1521	P	PPL	ZM		03				4061		765	Africa/Lusaka	2012-01-17
+921028	Chadiza	Chadiza	Chadiza	-14.06779	32.43917	P	PPL	ZM		03				3690		1066	Africa/Lusaka	2012-01-17
+878549	Zvishavane	Zvishavane	Shabani,Shavani,Zvishavane	-20.32674	30.06648	P	PPL	ZW		08				35896		998	Africa/Harare	2014-05-12
+879431	Victoria Falls	Victoria Falls	Chutes Victoria,VFA,Victoria Falls	-17.93285	25.83066	P	PPL	ZW		06	889941			35761		983	Africa/Harare	2015-01-14
+881164	Shurugwi	Shurugwi	Churugwi,Salukwe,Selukwe,Shurugwi	-19.67016	30.00589	P	PPL	ZW		02				17075		1483	Africa/Harare	2012-01-17
+881331	Shangani	Shangani		-19.78333	29.36667	P	PPL	ZW		02				3835		1377	Africa/Harare	2013-03-12
+881345	Shamva	Shamva	Shamva,Tsambvi,Tsamvi	-17.31159	31.57561	P	PPL	ZW		03				10317		947	Africa/Harare	2014-04-06
+882100	Rusape	Rusape	Rusape,Rusapi	-18.52785	32.12843	P	PPL	ZW		01				29292		1415	Africa/Harare	2012-01-17
+882599	Redcliff	Redcliff	Redcliff,Redcliffe,Rehdkliff,Ð ÑÐ´ÐºÐ»Ð¸Ñ„Ñ„	-19.03333	29.78333	P	PPL	ZW		02				33197		1232	Africa/Harare	2013-03-12
+882722	Raffingora	Raffingora	Raffingora	-17.03333	30.43333	P	PPL	ZW		00				1957		1160	Africa/Harare	2012-01-17
+882859	Plumtree	Plumtree	Plumtree	-20.48333	27.81667	P	PPL	ZW		07				2148		1384	Africa/Harare	2013-03-12
+882955	Penhalonga	Penhalonga	Penhalonga	-18.89112	32.69781	P	PPL	ZW		01				7681		1364	Africa/Harare	2012-01-17
+883183	Odzi	Odzi	Odzi	-18.96167	32.40557	P	PPL	ZW		01				3438		1005	Africa/Harare	2012-01-17
+883258	Nyazura	Nyazura	Inyazura,Nyazura,Nyazure	-18.70587	32.16796	P	PPL	ZW		01				2110		1243	Africa/Harare	2012-01-17
+883481	Nyanga	Nyanga		-18.21667	32.75	P	PPL	ZW		01				4852		1706	Africa/Harare	2013-03-12
+884141	Norton	Norton	Norton,ÐÐ¾Ñ€Ñ‚Ð¾Ð½	-17.88333	30.7	P	PPL	ZW		05				52054		1364	Africa/Harare	2013-03-12
+884798	Mvurwi	Mvurwi	Dawsons,Mvurwi,Umvukwes	-17.03333	30.85	P	PPL	ZW		03				7970		1495	Africa/Harare	2013-03-12
+884814	Mvuma	Mvuma	Muvumi,Mvuma,Umvuma	-19.27924	30.52828	P	PPL	ZW		02				4331		1387	Africa/Harare	2012-01-17
+884927	Mutoko	Mutoko	Mtoko,Mutoko	-17.39699	32.22677	P	PPL	ZW		04				9532		1285	Africa/Harare	2012-01-17
+884979	Mutare	Mutare	Gorad Mutareh,Mutare,MutarÄ—,Nyautare,UTA,Umtali,mu ta lei,mutale,Ð“Ð¾Ñ€Ð°Ð´ ÐœÑƒÑ‚Ð°Ñ€Ñ,ÐœÑƒÑ‚Ð°Ñ€Ðµ,ç©†å¡”é›·,ë¬´íƒ€ë ˆ	-18.9707	32.67086	P	PPLA	ZW		01				184205		1116	Africa/Harare	2010-08-03
+885159	Murehwa	Murehwa	Mrewa,Murehwa,Murewa	-17.64322	31.784	P	PPL	ZW		04				8559		1365	Africa/Harare	2014-05-12
+885800	Mount Darwin	Mount Darwin	Darwin,Fura,Mount Darwin,Mount Fura	-16.77251	31.58381	P	PPL	ZW		03				6349		955	Africa/Harare	2014-04-06
+886146	Mhangura	Mhangura	Mangula,Mhangura	-16.89387	30.16828	P	PPL	ZW		05				6503		1182	Africa/Harare	2014-04-06
+886384	Mazowe	Mazowe	Mazowe	-17.50404	30.97388	P	PPL	ZW		03				9966		1249	Africa/Harare	2014-03-19
+886763	Masvingo	Masvingo	Fort Victoria,MVZ,Mashvingo,Masvingo,Nyanda,ÐœÐ°ÑˆÐ²Ð¸Ð½Ð³Ð¾	-20.06373	30.82766	P	PPLA	ZW		08				76290		1091	Africa/Harare	2010-08-03
+886864	Mashava	Mashava	Mashaba,Mashava	-20.03665	30.48225	P	PPL	ZW		08				12994		1046	Africa/Harare	2012-01-17
+886990	Marondera	Marondera	Marandellas,Marondera	-18.18527	31.55193	P	PPLA	ZW		04				57082		1668	Africa/Harare	2010-08-03
+888089	Macheke	Macheke	Macheke,Mucheki	-18.13901	31.84933	P	PPL	ZW		04				3642		1527	Africa/Harare	2012-01-17
+888225	Lupane	Lupane	Lupane,Lupani	-18.93149	27.80696	P	PPLA	ZW		06				1200		1016	Africa/Harare	2010-08-13
+888667	Lalapanzi	Lalapanzi	Lalapansi,Lalapanzi	-19.33225	30.17768	P	PPL	ZW		02				1390		1500	Africa/Harare	2012-01-17
+888710	Kwekwe	Kwekwe	Hwe Hwe,Kwekwe,Que Que	-18.92809	29.81486	P	PPL	ZW		02				99149		1203	Africa/Harare	2012-01-17
+889191	Karoi	Karoi	Karoi,Karoyi	-16.80993	29.69247	P	PPL	ZW		05				25030		1259	Africa/Harare	2015-04-24
+889215	Kariba	Kariba	KAB,Kariba,ÐšÐ°Ñ€Ð¸Ð±Ð°	-16.51667	28.8	P	PPL	ZW		05				25531		679	Africa/Harare	2012-01-17
+889390	Kamativi Mine	Kamativi Mine	Kamativi,Kamativi Mine,Kamitivi	-18.31563	27.05729	P	PPL	ZW		06				1575		953	Africa/Harare	2012-01-17
+889453	Kadoma	Kadoma	Gatooma,Kadoma,Kadome,Katoma,ÐšÐ°Ð´Ð¾Ð¼Ðµ	-18.33328	29.91534	P	PPL	ZW		05				79174		1176	Africa/Harare	2012-01-17
+889723	Inyati	Inyati	Inyati	-19.67563	28.84687	P	PPL	ZW		06				8402		1333	Africa/Harare	2014-03-23
+889795	Insiza	Insiza		-19.78333	29.2	P	PPL	ZW		07				2645		1422	Africa/Harare	2013-03-12
+889942	Hwange	Hwange	Khvange,WKI,Wange,Wankie,Ð¥Ð²Ð°Ð½Ð³Ðµ	-18.36446	26.49877	P	PPL	ZW		06	889941			33210		784	Africa/Harare	2014-11-16
+890242	Headlands	Headlands	Headlands	-18.27733	32.0515	P	PPL	ZW		01				1728		1563	Africa/Harare	2012-01-17
+890299	Harare	Harare	Arare,Charare,Gorad Kharareh,HRE,Harare,Hararensis Urbs,Harareo,HararÄ—,Kharare,Salisbury,ha la lei,halale,harare,harary,hrarh,hrary,Î§Î±ÏÎ¬ÏÎµ,Ð“Ð¾Ñ€Ð°Ð´ Ð¥Ð°Ñ€Ð°Ñ€Ñ,Ð¥Ð°Ñ€Ð°Ñ€Ðµ,Õ€Õ¡Ö€Õ¡Ö€Õ¥,×”××¨××¨×”,Ù‡Ø§Ø±Ø§Ø±Ù‰,Ù‡Ø±Ø§Ø±Ù‡,Ù‡Ø±Ø§Ø±ÙŠ,Ú¾Ø§Ø±Ø§Ø±Û,Ú¾Û•Ø±Ø§Ø±ÛŽ,ÛØ±Ø§Ø±Û’,à¤¹à¤°à¤¾à¤°à¥‡,à¨¹à¨°à¨¾à¨°à©‡,à¬¹à¬¾à¬°à¬¾à¬°à­‡,à®¹à®°à®¾à®°à¯‡,à¸®à¸²à¸£à¸²à¹€à¸£,à½§à¼‹à½¢à¼‹à½¢à½²à¼,áƒ°áƒáƒ áƒáƒ áƒ”,áˆ€áˆ«áˆ¬,ãƒãƒ©ãƒ¬,å“ˆæ‹‰é›·,í•˜ë¼ë ˆ	-17.82772	31.05337	P	PPLC	ZW		10				1542813		1494	Africa/Harare	2012-04-23
+890422	Gweru	Gweru	GWE,Gveru,Gwelo,Gweru,Ð“Ð²ÐµÑ€Ñƒ	-19.45	29.81667	P	PPLA	ZW		02				146073		1412	Africa/Harare	2009-06-30
+890516	Gwanda	Gwanda	Jawunda	-20.93333	29	P	PPLA	ZW		07				14450		982	Africa/Harare	2009-06-30
+890983	Gokwe	Gokwe	Gokwe	-18.20476	28.9349	P	PPL	ZW		02				18942		1237	Africa/Harare	2012-05-05
+891099	Glendale	Glendale	Glendale	-17.35514	31.06718	P	PPL	ZW		03				9768		1143	Africa/Harare	2012-01-17
+891515	Filabusi	Filabusi	Emfelabuso,Filabusi	-20.53333	29.28502	P	PPL	ZW		07				1756		1072	Africa/Harare	2012-01-17
+891699	Esigodini	Esigodini	Esigodini,Essexvale	-20.28979	28.92261	P	PPL	ZW		07				2228		1181	Africa/Harare	2012-01-17
+892156	Dorowa Mining Lease	Dorowa Mining Lease	Dorowa,Dorowa Claims,Dorowa Mining Lease	-19.06667	31.75	P	PPL	ZW		00				1676		916	Africa/Harare	2012-01-17
+892440	Dete	Dete	Dete,Dett	-18.61667	26.86667	P	PPL	ZW		06				2993		1112	Africa/Harare	2013-03-12
+892876	Concession	Concession	Concession	-17.38333	30.95	P	PPL	ZW		03				4983		1331	Africa/Harare	2013-03-12
+893172	Chivhu	Chivhu	Chivhu,Enkeldoorn	-19.02112	30.89218	P	PPL	ZW		04				10369		1450	Africa/Harare	2012-01-17
+893397	Chirundu	Chirundu	Chirunda,Chirundo,Chirundu,Chirundu Township,Otto Beit Bridge	-16.03333	28.85	P	PPL	ZW		00				1911		402	Africa/Harare	2012-01-17
+893485	Chiredzi	Chiredzi	BFO,Chiredzi	-21.05	31.66667	P	PPL	ZW		08				28205		436	Africa/Harare	2013-05-08
+893549	Chipinge	Chipinge	CHJ,Chipinga,Chipinge	-20.18833	32.62365	P	PPL	ZW		01				18860		1109	Africa/Harare	2015-04-24
+893697	Chinhoyi	Chinhoyi	Chinhoyi,Chinoyi,Sinoia	-17.36667	30.2	P	PPLA	ZW		05				61739		1153	Africa/Harare	2009-06-30
+893813	Chimanimani	Chimanimani	Chimanimani,Mandidzudzure,Melsetter	-19.8	32.86667	P	PPL	ZW		01				2752		1565	Africa/Harare	2013-03-12
+894239	Chegutu	Chegutu	Cheguto,Chegutu,Hartley,New Hartley	-18.13021	30.14074	P	PPL	ZW		05				47294		1187	Africa/Harare	2012-01-17
+894413	Chakari	Chakari	Chakari,Shagari	-18.06294	29.89246	P	PPL	ZW		05				6472		1107	Africa/Harare	2012-01-17
+894460	Centenary	Centenary	Centenary	-16.72289	31.11462	P	PPL	ZW		03				3388		1186	Africa/Harare	2012-01-17
+894701	Bulawayo	Bulawayo	BUQ,Bulavajas,Bulavajo,Bulavejo,Bulawayo,Gorad Bulavajo,bu la wa yue,bullawayo,burawayo,Ð‘ÑƒÐ»Ð°Ð²Ð°Ð¹Ð¾,Ð‘ÑƒÐ»Ð°Ð²Ð°Ñ˜Ð¾,Ð‘ÑƒÐ»Ð°Ð²ÐµÐ¹Ð¾,Ð“Ð¾Ñ€Ð°Ð´ Ð‘ÑƒÐ»Ð°Ð²Ð°Ñ‘,ãƒ–ãƒ©ãƒ¯ãƒ¨,å¸ƒæ‹‰ç“¦çº¦,ë¶ˆë¼ì™€ìš”	-20.15	28.58333	P	PPLA	ZW		09				699385		1348	Africa/Harare	2010-08-03
+895057	Binga	Binga	Binga	-17.62027	27.34139	P	PPL	ZW		06				4327		628	Africa/Harare	2012-01-17
+895061	Bindura	Bindura	Bindura,Bindura Town,Kimberley Reefs,Ð‘Ð¸Ð½Ð´ÑƒÑ€Ð°	-17.30192	31.33056	P	PPLA	ZW		03				37423		1118	Africa/Harare	2010-08-03
+895269	Beitbridge	Beitbridge	Beitbridge	-22.21667	30	P	PPL	ZW		07				26459		461	Africa/Harare	2013-03-12
+895308	Beatrice	Beatrice		-18.25283	30.8473	P	PPL	ZW		04				1647		1307	Africa/Harare	2006-01-17
+895417	Banket	Banket	Banket,Banket Junction	-17.38333	30.4	P	PPL	ZW		05				9641		1277	Africa/Harare	2013-03-12
+1085510	Epworth	Epworth	Epworth	-17.89	31.1475	P	PPLX	ZW		10				123250		1508	Africa/Harare	2012-01-19
+1106542	Chitungwiza	Chitungwiza	Chitungwiza	-18.01274	31.07555	P	PPL	ZW		10				340360		1435	Africa/Harare	2012-01-20
+

--- a/spec/models/local_authority_spec.rb
+++ b/spec/models/local_authority_spec.rb
@@ -1,0 +1,75 @@
+require 'spec_helper'
+
+describe LocalAuthority, :type => :model do
+
+  def harvest_tsv
+    LocalAuthority.harvest_tsv("geo", [fixture_path + '/geonames.tsv'], prefix: 'http://sws.geonames.org/')
+  end
+
+  before :all do
+    class MyTestRdfDatastream; end
+  end
+
+  after :all do
+    Object.send(:remove_const, :MyTestRdfDatastream)
+  end
+
+  it "should harvest TSV vocabs" do
+    harvest_tsv
+    expect(LocalAuthority.count).to eq(1)
+    auth = LocalAuthority.where(name: "geo").first
+    expect(LocalAuthorityEntry.where(local_authority_id: auth.id).first.uri).to start_with('http://sws.geonames.org/')
+    expect(LocalAuthorityEntry.count).to eq(149)
+  end
+
+  describe "when vocabs are harvested" do
+
+    let(:num_auths)   { LocalAuthority.count }
+    let(:num_entries) { LocalAuthorityEntry.count }
+
+    before do
+      harvest_tsv
+    end
+
+    it "should not have any initial domain terms" do
+      expect(DomainTerm.count).to eq(0)
+    end
+
+    it "should not harvest a TSV vocab twice" do
+      harvest_tsv
+      expect(LocalAuthority.count).to eq(num_auths)
+      expect(LocalAuthorityEntry.count).to eq(num_entries)
+    end
+    it "should register a vocab" do
+      LocalAuthority.register_vocabulary(MyTestRdfDatastream, "geographic", "geo")
+      expect(DomainTerm.count).to eq(1)
+    end
+
+    describe "when vocabs are registered" do
+
+      before do
+        LocalAuthority.register_vocabulary(MyTestRdfDatastream, "geographic", "geo")
+      end
+
+      it "should have some doamin terms" do
+        expect(DomainTerm.count).to eq(1)
+      end
+
+      it "should return nil for empty queries" do
+        expect(LocalAuthority.entries_by_term("my_test", "geographic", "")).to be_nil
+      end
+      it "should return an empty array for unregistered models" do
+        expect(LocalAuthority.entries_by_term("my_foobar", "geographic", "E")).to eq([])
+      end
+      it "should return an empty array for unregistered terms" do
+        expect(LocalAuthority.entries_by_term("my_test", "foobar", "E")).to eq([])
+      end
+      it "should return entries by term" do
+        term = DomainTerm.where(model: "my_tests", term: "geographic").first
+        authorities = term.local_authorities.collect(&:id).uniq
+        hits = LocalAuthorityEntry.where("local_authority_id in (?)", authorities).where("label like ?", "E%").select("label, uri").limit(25)
+        expect(LocalAuthority.entries_by_term("my_tests", "geographic", "E").count).to eq(2)
+      end
+    end
+  end
+end


### PR DESCRIPTION
It adds:
* a list of hydranorth rake tasks, including characterize, checksum, export all items, and creating derivatives, list of failed resque jobs, resolrize all items and harvest controlled vocabularies with LocalAuthority. 
* add geonames to local mysql database in local_authorities and local_authority_entries table
* add the harvest rake task to reset-all script 
* the list of geonames are getting from geonames.org in real time of harvesting. 
