### PR TITLE
Freshclam

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ services:
 before_install:
   - sudo apt-get update
   - sudo apt-get install libclamav-dev clamav-freshclam
-  - freshclam
+  - sudo freshclam
 before_script:
   - redis-cli info
   - bundle exec rake jetty:start

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ services:
 before_install:
   - sudo apt-get update
   - sudo apt-get install libclamav-dev clamav-freshclam
+  - freshclam
 before_script:
   - redis-cli info
   - bundle exec rake jetty:start


### PR DESCRIPTION
Add "sudo freshclam" to .travis.yml before_install step. We don't actually need the updated virus db, but we get intermittent failures to install any clamav data, which causes the test run to fail on Travis. This step should prevent that.