### PR TITLE
Migration fixes

### DIFF
--- a/lib/tasks/migration.rake
+++ b/lib/tasks/migration.rake
@@ -302,6 +302,11 @@ namespace :migration do
         File.open(ODDITIES, 'a') {|f| f.puts("#{Time.now} NO LICENSE - #{uuid}") }
       else
         license = license_node.attribute('LABEL').to_s
+        # exclude objects with a license file or text that is longer than 250 characters,  
+        # before we have plan to deal with these items.  
+        MigrationLogger.warn "#{uuid} license is a file or text is longer than 250 characters"
+        next if license=~/^.*\.(pdf|PDF|txt|TXT|doc|DOC)$/ || license.length > 250
+
       end
       #get the relsext metadata
       relsext_version = metadata.xpath("//foxml:datastreamVersion[contains(@ID, 'RELS-EXT.')]//rdf:Description",NS).last

--- a/lib/tasks/user_migration.rake
+++ b/lib/tasks/user_migration.rake
@@ -67,6 +67,7 @@ namespace :migration do
             MigrationLogger.info "FAILED: User #{id} #{username} has not migrated."
           end
           n = n + 1
+          ActiveRecord::Base.connection.close
         rescue Exception => e
           puts "FAILED: User #{id} migration at #{n}!"
           puts e.message


### PR DESCRIPTION
* exclude objects with license files or long (longer than 250 characters) license text from migration, until we have established a plan on how to deal these objects. 
* close mysql connection after each user's migration as ActiveRecord doesn't close the connection automatically. 