### PR TITLE
Special report detail page

### DIFF
--- a/app/presenters/hydranorth/cstr_presenter.rb
+++ b/app/presenters/hydranorth/cstr_presenter.rb
@@ -3,7 +3,7 @@ module Hydranorth
     include Hydra::Presenter
     self.model_class = ::GenericFile
     # Terms is the list of fields displayed by app/views/generic_files/_show_descriptions.html.erb
-    self.terms = [:resource_type, :title, :trid, :creator, :contributor, :description, :date_created, :license, :subject, :spatial, :temporal, :is_version_of, :source, :related_url, :language]
+    self.terms = [:title, :creator, :contributor, :subject, :resource_type, :trid, :language, :spatial, :temporal, :description, :date_created, :license, :is_version_of, :source, :related_url]
 
   end
 end

--- a/app/presenters/hydranorth/ser_presenter.rb
+++ b/app/presenters/hydranorth/ser_presenter.rb
@@ -3,7 +3,7 @@ module Hydranorth
     include Hydra::Presenter
     self.model_class = ::GenericFile
     # Terms is the list of fields displayed by app/views/generic_files/_show_descriptions.html.erb
-    self.terms = [:resource_type, :title, :ser, :creator, :contributor, :description, :date_created, :license, :subject, :spatial, :temporal, :is_version_of, :source, :related_url, :language]
+    self.terms = [:title, :creator, :contributor, :subject, :resource_type, :ser, :language, :spatial, :temporal, :description, :date_created, :license, :is_version_of, :source, :related_url]
 
   end
 end


### PR DESCRIPTION
PR includes:
* make the order of fields on special reports record page to be consistent with regular generic file
* add a rake task to update the resource type for special reports (they are currently set as 'report' during migration) - Metadata team is going to evaluate the metadata value they'd like to use, some functions may require refactoring/new development after their decision. This rake task will fix #296 
