### PR TITLE
License display bug 

### DIFF
--- a/app/views/records/edit_fields/_language.html.erb
+++ b/app/views/records/edit_fields/_language.html.erb
@@ -1,4 +1,2 @@
  <%= f.input :language, as: :select_with_modal_help, collection: Sufia.config.languages,
           input_html: { class: 'form-control', required: true }, include_blank: true %>
-~
-

--- a/app/views/records/edit_fields/_license.html.erb
+++ b/app/views/records/edit_fields/_license.html.erb
@@ -1,3 +1,9 @@
- <%= f.input :license, as: :select_with_modal_help, collection: Sufia.config.cc_licenses,
-          input_html: { class: 'form-control', required: true }, include_blank: true %>
+<% if Sufia.config.cc_licenses_reverse.has_key?(@generic_file.license) %>
+  <%= f.input :license, as: :select_with_modal_help, collection: Sufia.config.cc_licenses,
+ input_html: { class: 'form-control', required: true }, include_blank: true %>
+<% else %>
+  <%= f.input :license, as: :select_with_modal_help, collection: Sufia.config.cc_licenses.dup.merge({@generic_file.license => @generic_file.license}),  
+ input_html: { class: 'form-control', required: true }, include_blank: true %>
+<% end %>
  <%= render "collections/license_modal" %>
+

--- a/app/views/records/show_fields/_license.html.erb
+++ b/app/views/records/show_fields/_license.html.erb
@@ -1,3 +1,7 @@
 <% unless record.license.nil? %>
-<%=link_to_field('license',record.license, Sufia.config.cc_licenses_reverse[record.license])%> <%= iconify_auto_link(record.license,false) %><br />
+<% if Sufia.config.cc_licenses.has_key?(record.license) %>
+  <%=link_to_field('license',record.license, Sufia.config.cc_licenses_reverse[record.license])%> <%= iconify_auto_link(record.license,false) %><br />
+<% else %>
+  <%=link_to_field('license',record.license, record.license)%><br />
+<% end %>
 <% end %>

--- a/config/initializers/sufia.rb
+++ b/config/initializers/sufia.rb
@@ -19,7 +19,6 @@ Sufia.config do |config|
     'Attribution-NonCommercial-ShareAlike 4.0 International' => 'http://creativecommons.org/licenses/by-nc-sa/4.0/',
     'Public Domain Mark 1.0' => 'http://creativecommons.org/publicdomain/mark/1.0/',
     'CC0 1.0 Universal' => 'http://creativecommons.org/publicdomain/zero/1.0/',
-    'All rights reserved' => 'All rights reserved'
   }
 
   config.cc_licenses_reverse = Hash[*config.cc_licenses.to_a.flatten.reverse]


### PR DESCRIPTION
This PR includes:
* fix for #277 display only one licence term for the non-standard migrated license
* fix the issue of when editing migrated object with non-standard license, no value would be selected and force user to make a selection. 
* remove "All rights reserved" from the license dropdown according to  #282  

Will need to add spec test after the soft launch. 