### PR TITLE
fixes collection creation issue fixes #348

### DIFF
--- a/app/views/records/edit_fields/_license.html.erb
+++ b/app/views/records/edit_fields/_license.html.erb
@@ -1,9 +1,10 @@
-<% if Sufia.config.cc_licenses_reverse.has_key?(@generic_file.license) %>
+<% if @generic_file.nil? || @generic_file.license.blank? || Sufia.config.cc_licenses_reverse.has_key?(@generic_file.license) %>
   <%= f.input :license, as: :select_with_modal_help, collection: Sufia.config.cc_licenses,
  input_html: { class: 'form-control', required: true }, include_blank: true %>
 <% else %>
   <%= f.input :license, as: :select_with_modal_help, collection: Sufia.config.cc_licenses.dup.merge({@generic_file.license => @generic_file.license}),  
  input_html: { class: 'form-control', required: true }, include_blank: true %>
 <% end %>
+
  <%= render "collections/license_modal" %>
 


### PR DESCRIPTION
The error was introduced by PR #340 (when trying to fix the issue of when editing migrated object with non-standard license, no value would be selected and force user to make a selection.)