### PR TITLE
change upload sizes to fix #253

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,8 +15,12 @@
 //
 // Required by Blacklight
 //= require blacklight/blacklight
-//= require_tree .
 //
 //= require sufia
+//
 //= require jquery.hoverIntent.min
+//= require jquery.canvasjs.min
+//= require twitterFetcher_min
+//
 //= require custom
+//= require hydranorth_fileupload

--- a/app/assets/javascripts/hydranorth_fileupload.js
+++ b/app/assets/javascripts/hydranorth_fileupload.js
@@ -1,0 +1,6 @@
+//1 GB max file size 
+max_file_size = 1000000000;
+max_file_size_str = "1 GB";
+//1.5 GB max total upload size
+max_total_file_size = 1500000000;
+max_total_file_size_str = "1.5 GB";


### PR DESCRIPTION
Does not fix Apache configuration and disk size restrictions.  Ensure that the LimitRequestBody or SecRequestBodyLimit  is set for httpd. Also ensure that /tmp directory is large enough to contain 1GB files and 1.5 GB groups of files for a few users or configure Passenger to use a different directory.