### PR TITLE
Fix my misfixed ualterms namespace

### DIFF
--- a/lib/rdf_vocabularies/ualterms.rb
+++ b/lib/rdf_vocabularies/ualterms.rb
@@ -1,4 +1,4 @@
-class UALTerms < RDF::Vocabulary("http://terms.library.library.ca/identifiers/")
+class UALTerms < RDF::Vocabulary("http://terms.library.ualberta.ca/identifiers/")
   property :trid
   property :ser
   property :unicorn

--- a/lib/tasks/dataverse_migration.rake
+++ b/lib/tasks/dataverse_migration.rake
@@ -7,7 +7,7 @@ require './lib/tasks/migration/migration_logger'
         "xmlns:dc"=>"http://purl.org/dc/elements/1.1/", 
         "xmlns:dcterms"=>"http://purl.org/dc/terms/", 
         "xmlns:oai_dc"=>"http://www.openarchives.org/OAI/2.0/oai_dc/", 
-        "xmlns:ualterms"=>"http://terms.library.library.ca", 
+        "xmlns:ualterms"=>"http://terms.library.ualberta.ca", 
     }
 
 

--- a/lib/tasks/migration.rake
+++ b/lib/tasks/migration.rake
@@ -9,7 +9,7 @@ require './lib/tasks/migration/migration_logger'
         "xmlns:dc"=>"http://purl.org/dc/elements/1.1/", 
         "xmlns:dcterms"=>"http://purl.org/dc/terms/", 
         "xmlns:oai_dc"=>"http://www.openarchives.org/OAI/2.0/oai_dc/", 
-        "xmlns:ualterms"=>"http://terms.library.library.ca", 
+        "xmlns:ualterms"=>"http://terms.library.ualberta.ca", 
         "memberof"=>"info:fedora/fedora-system:def/relations-external#", 
         "xmlns:rdf"=>"http://www.w3.org/1999/02/22-rdf-syntax-ns#", 
         "userns"=>"http://era.library.ualberta.ca/schema/definitions.xsd#"

--- a/lib/tasks/migration/collection/cci_images.xml
+++ b/lib/tasks/migration/collection/cci_images.xml
@@ -82,7 +82,7 @@
   <foxml:datastream ID="DCQ" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
     <foxml:datastreamVersion ID="DCQ.2" LABEL="Circumpolar Digital Image Collection" CREATED="2011-11-14T22:17:48.055Z" MIMETYPE="text/xml">
       <foxml:xmlContent>
-        <dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:ualterms="http://terms.library.library.ca">
+        <dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:ualterms="http://terms.library.ualberta.ca">
           <dcterms:identifier>uuid:3f5739f8-4344-4ce5-9f85-9bda224b41d7</dcterms:identifier>
           <dcterms:identifier>http://hdl.handle.net/10402/era.17512</dcterms:identifier>
           <dcterms:title>Circumpolar Digital Image Collection</dcterms:title>

--- a/lib/tasks/migration/community/cci.xml
+++ b/lib/tasks/migration/community/cci.xml
@@ -106,7 +106,7 @@
 	<foxml:datastream ID="DCQ" STATE="A" CONTROL_GROUP="X" VERSIONABLE="true">
 		<foxml:datastreamVersion ID="DC.2" LABEL="Canadian Circumpolar Institute" CREATED="2013-09-20T19:45:30.028Z" MIMETYPE="text/xml">
 			<foxml:xmlContent>
-				<dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:ualterms="http://terms.library.library.ca">
+				<dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:ualterms="http://terms.library.ualberta.ca">
 					<dcterms:identifier>uuid:d04b3b74-211d-4939-9660-c390958fa2ee</dcterms:identifier>
 					<dcterms:identifier>http://hdl.handle.net/10402/era.17144</dcterms:identifier>
 					<dcterms:title>Canadian Circumpolar Institute</dcterms:title>

--- a/lib/tasks/migration/test-metadata/collection/circimage_coll.foxml.xml
+++ b/lib/tasks/migration/test-metadata/collection/circimage_coll.foxml.xml
@@ -247,7 +247,7 @@
 <foxml:datastream CONTROL_GROUP="X" ID="DCQ" STATE="A" VERSIONABLE="true">
 <foxml:datastreamVersion ID="DCQ.0" LABEL="Item Metadata" MIMETYPE="text/xml">
 <foxml:xmlContent>
-<dc xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ualterms="http://terms.library.library.ca" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<dc xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ualterms="http://terms.library.ualberta.ca" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <ualterms:fedora3uuid xsi:type="string">uuid:3f5739f8-4344-4ce5-9f85-9bda224b41d7</ualterms:fedora3uuid>
   <ualterms:fedora3handle xsi:type="anyURI">http://hdl.handle.net/10402/era.17512</ualterms:fedora3handle>
   <dcterms:title>Circumpolar Digital Image Collection</dcterms:title>

--- a/lib/tasks/migration/test-metadata/collection/comp_sci_tech_reports_coll.xml
+++ b/lib/tasks/migration/test-metadata/collection/comp_sci_tech_reports_coll.xml
@@ -445,7 +445,7 @@
 <foxml:datastream CONTROL_GROUP="X" ID="DCQ" STATE="A" VERSIONABLE="true">
 <foxml:datastreamVersion ID="DCQ.0" LABEL="Item Metadata" MIMETYPE="text/xml">
 <foxml:xmlContent>
-<dc xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ualterms="http://terms.library.library.ca" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<dc xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ualterms="http://terms.library.ualberta.ca" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <ualterms:fedora3uuid xsi:type="string">uuid:33713a7b-b387-4a7e-8d9e-860df87c1fe5</ualterms:fedora3uuid>
   <ualterms:fedora3handle xsi:type="anyURI">http://hdl.handle.net/10402/era.26345</ualterms:fedora3handle>
   <dcterms:title>Technical Reports</dcterms:title>

--- a/lib/tasks/migration/test-metadata/collection/env_impact_assess_reports_coll.xml
+++ b/lib/tasks/migration/test-metadata/collection/env_impact_assess_reports_coll.xml
@@ -723,7 +723,7 @@
 <foxml:datastream CONTROL_GROUP="X" ID="DCQ" STATE="A" VERSIONABLE="true">
 <foxml:datastreamVersion ID="DCQ.0" LABEL="Item Metadata" MIMETYPE="text/xml">
 <foxml:xmlContent>
-<dc xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ualterms="http://terms.library.library.ca" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<dc xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ualterms="http://terms.library.ualberta.ca" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <ualterms:fedora3uuid xsi:type="string">uuid:19e840dc-b8ec-42ec-8a1b-73d59e631f27</ualterms:fedora3uuid>
   <ualterms:fedora3handle xsi:type="anyURI">http://hdl.handle.net/10402/era.38903</ualterms:fedora3handle>
   <dcterms:title>Environmental Impact Assessment Reports</dcterms:title>

--- a/lib/tasks/migration/test-metadata/community/cci_comm.foxml.xml
+++ b/lib/tasks/migration/test-metadata/community/cci_comm.foxml.xml
@@ -346,7 +346,7 @@
 <foxml:datastream CONTROL_GROUP="X" ID="DCQ" STATE="A" VERSIONABLE="true">
 <foxml:datastreamVersion ID="DCQ.0" LABEL="Item Metadata" MIMETYPE="text/xml">
 <foxml:xmlContent>
-<dc xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ualterms="http://terms.library.library.ca" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<dc xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ualterms="http://terms.library.ualberta.ca" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <ualterms:fedora3uuid xsi:type="string">uuid:d04b3b74-211d-4939-9660-c390958fa2ee</ualterms:fedora3uuid>
   <ualterms:fedora3handle xsi:type="anyURI">http://hdl.handle.net/10402/era.17144</ualterms:fedora3handle>
   <dcterms:title>Canadian Circumpolar Institute</dcterms:title>

--- a/lib/tasks/migration/test-metadata/community/dept_comp_sci_comm.xml
+++ b/lib/tasks/migration/test-metadata/community/dept_comp_sci_comm.xml
@@ -143,7 +143,7 @@
 <foxml:datastream CONTROL_GROUP="X" ID="DCQ" STATE="A" VERSIONABLE="true">
 <foxml:datastreamVersion ID="DCQ.0" LABEL="Item Metadata" MIMETYPE="text/xml">
 <foxml:xmlContent>
-<dc xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ualterms="http://terms.library.library.ca" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<dc xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ualterms="http://terms.library.ualberta.ca" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <ualterms:fedora3uuid xsi:type="string">uuid:78cb4c52-d943-4879-96f7-bdc4424620a8</ualterms:fedora3uuid>
   <ualterms:fedora3handle xsi:type="anyURI">http://hdl.handle.net/10402/era.26343</ualterms:fedora3handle>
   <dcterms:title>Department of Computing Science</dcterms:title>

--- a/lib/tasks/migration/test-metadata/community/osrin_comm.xml
+++ b/lib/tasks/migration/test-metadata/community/osrin_comm.xml
@@ -685,7 +685,7 @@
 <foxml:datastream CONTROL_GROUP="X" ID="DCQ" STATE="A" VERSIONABLE="true">
 <foxml:datastreamVersion ID="DCQ.0" LABEL="Item Metadata" MIMETYPE="text/xml">
 <foxml:xmlContent>
-<dc xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ualterms="http://terms.library.library.ca" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<dc xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ualterms="http://terms.library.ualberta.ca" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <ualterms:fedora3uuid xsi:type="string">uuid:81b7dcc7-78f7-4adf-a703-6688b82090f5</ualterms:fedora3uuid>
   <dcterms:title>Oil Sands Research and Information Network (OSRIN)</dcterms:title>
   <dcterms:creator>Administrator admin</dcterms:creator>

--- a/lib/tasks/migration/test-metadata/uuid_07185c11-20f1-445e-990f-db5cfdc71f47.xml
+++ b/lib/tasks/migration/test-metadata/uuid_07185c11-20f1-445e-990f-db5cfdc71f47.xml
@@ -67,7 +67,7 @@
   <foxml:datastream CONTROL_GROUP="X" ID="DC" STATE="A" VERSIONABLE="true">
     <foxml:datastreamVersion CREATED="2014-12-04T03:58:53.101Z" FORMAT_URI="http://www.openarchives.org/OAI/2.0/oai_dc/" ID="DC1.0" LABEL="Dublin Core Record for this object" MIMETYPE="text/xml">
       <foxml:xmlContent>
-        <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ualterms="http://terms.library.library.ca" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd
+        <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ualterms="http://terms.library.ualberta.ca" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd
           <dc:title>Above ground utilities in Yakutsk, Russia</dc:title>
           <dc:identifier>uuid:07185c11-20f1-445e-990f-db5cfdc71f47</dc:identifier>
         </oai_dc:dc>
@@ -191,7 +191,7 @@
   <foxml:datastream CONTROL_GROUP="X" ID="DCQ" STATE="A" VERSIONABLE="true">
 <foxml:datastreamVersion CREATED="2014-12-04T03:58:54.904Z" ID="DCQ.0" LABEL="Item Metadata" MIMETYPE="text/xml">
       <foxml:xmlContent>
-        <dc xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ualterms="http://terms.library.library.ca">
+        <dc xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ualterms="http://terms.library.ualberta.ca">
           <dcterms:creator>Campbell, Sandy</dcterms:creator>
           <dcterms:description>Because Yakutsk is on permafrost, utilities must be above ground.  The city is heated by hot water boilers in several sectors.  Hot water is carried through pipes like these to heat the city.</dcterms:description>
           <dcterms:format xsi:type="dcterms:IMT">image/jpeg</dcterms:format>

--- a/lib/tasks/migration/test-metadata/uuid_33d14471-afdd-4fa8-93cc-06d710525fe2.xml
+++ b/lib/tasks/migration/test-metadata/uuid_33d14471-afdd-4fa8-93cc-06d710525fe2.xml
@@ -224,7 +224,7 @@
   <foxml:datastream CONTROL_GROUP="X" ID="DCQ" STATE="A" VERSIONABLE="true">
 <foxml:datastreamVersion CREATED="2013-09-30T17:22:54.357Z" ID="DCQ.0" LABEL="Item Metadata" MIMETYPE="text/xml">
       <foxml:xmlContent>
-        <dc xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ualterms="http://terms.library.library.ca">
+        <dc xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ualterms="http://terms.library.ualberta.ca">
           <dcterms:creator>Hindle, Abram</dcterms:creator>
           <dcterms:creator>Jiang, Feng</dcterms:creator>
           <dcterms:creator>Wang, Jiemin</dcterms:creator>

--- a/lib/tasks/migration/test-metadata/uuid_473ac917-ee90-45b2-b527-f513114b43c5.xml
+++ b/lib/tasks/migration/test-metadata/uuid_473ac917-ee90-45b2-b527-f513114b43c5.xml
@@ -249,7 +249,7 @@
 <foxml:datastream CONTROL_GROUP="X" ID="DCQ" STATE="A" VERSIONABLE="true">
 <foxml:datastreamVersion ID="DCQ.0" LABEL="Item Metadata" MIMETYPE="text/xml">
 <foxml:xmlContent>
-<dc xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ualterms="http://terms.library.library.ca" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<dc xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ualterms="http://terms.library.ualberta.ca" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
           <ualterms:fedora3handle xsi:type="anyURI">http://hdl.handle.net/10402/era.23253</ualterms:fedora3handle>
           <dcterms:title>Adelie penguins -- photograph</dcterms:title>
           <dcterms:creator>Seale, Linda N.</dcterms:creator>

--- a/lib/tasks/migration/test-metadata/uuid_846f544d-94db-41b4-9f4a-654e1457ed8c.xml
+++ b/lib/tasks/migration/test-metadata/uuid_846f544d-94db-41b4-9f4a-654e1457ed8c.xml
@@ -1908,7 +1908,7 @@
   <foxml:datastream CONTROL_GROUP="X" ID="DCQ" STATE="A" VERSIONABLE="true">
 <foxml:datastreamVersion CREATED="2014-06-27T15:33:13.762Z" ID="DCQ.10" LABEL="Item Metadata" MIMETYPE="text/xml">
       <foxml:xmlContent>
-        <dc xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ualterms="http://terms.library.library.ca">
+        <dc xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ualterms="http://terms.library.ualberta.ca">
           <dcterms:creator>Suncor Inc., Oil Sands Group</dcterms:creator>
           <dcterms:description>Suncor Inc. is applying for regulatory approval to proceed with the development of the proposed Steepbank Mine, to be located across the Athabasca River from its current operations near Fort McMurray in the Regional Municipality of Wood Buffalo in northeastern Alberta. In April1995 a disclosure document was released for the proposed mine. Since then, a comprehensive public and regulatory consultation and communication program and an environmental impact assessment have been underway in parallel with engineering feasibility studies.
 This document comprises the Application for Approval of Steepbank Mine and serves to meet the requirements under the Alberta Oil Sands Conservation Act, the Alberta Environmental Protection and Enhancement Act and the Alberta Water Resources Act. It also includes the Environmental Impact Assessment.

--- a/lib/tasks/migration/test-metadata/uuid_96109189-16b9-40e8-9500-b8b9041d925e.xml
+++ b/lib/tasks/migration/test-metadata/uuid_96109189-16b9-40e8-9500-b8b9041d925e.xml
@@ -211,7 +211,7 @@
   <foxml:datastream CONTROL_GROUP="X" ID="DCQ" STATE="A" VERSIONABLE="true">
 <foxml:datastreamVersion CREATED="2014-05-01T15:14:52.600Z" ID="DCQ.0" LABEL="Item Metadata" MIMETYPE="text/xml">
       <foxml:xmlContent>
-        <dc xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ualterms="http://terms.library.library.ca">
+        <dc xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ualterms="http://terms.library.ualberta.ca">
           <dcterms:creator>Maani, Rouzbeh</dcterms:creator>
           <dcterms:creator>Yang, Yee-Hong</dcterms:creator>
           <dcterms:creator>Kalra, Sanjay</dcterms:creator>

--- a/spec/fixtures/migration/test-metadata/collection/circimage_coll.xml
+++ b/spec/fixtures/migration/test-metadata/collection/circimage_coll.xml
@@ -83,14 +83,14 @@
 <foxml:xmlContent>
 <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
   <dcterms:title>Circumpolar Photographs</dcterms:title>
-  <ualterms:fedora3uuid xmlns:ualterms="http://terms.library.library.ca" xsi:type="string">uuid:3f5739f8-4344-4ce5-9f85-9bda224b41d7</ualterms:fedora3uuid>
+  <ualterms:fedora3uuid xmlns:ualterms="http://terms.library.ualberta.ca" xsi:type="string">uuid:3f5739f8-4344-4ce5-9f85-9bda224b41d7</ualterms:fedora3uuid>
 </oai_dc:dc>
 </foxml:xmlContent>
 </foxml:datastreamVersion>
 <foxml:datastreamVersion ID="DC.1" LABEL="Circumpolar Photographs" CREATED="2010-07-26T14:24:55.465Z" MIMETYPE="text/xml" FORMAT_URI="http://www.openarchives.org/OAI/2.0/oai_dc/" SIZE="334">
 <foxml:xmlContent>
 <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
-  <ualterms:fedora3uuid xmlns:ualterms="http://terms.library.library.ca" xsi:type="string">uuid:3f5739f8-4344-4ce5-9f85-9bda224b41d7</ualterms:fedora3uuid>
+  <ualterms:fedora3uuid xmlns:ualterms="http://terms.library.ualberta.ca" xsi:type="string">uuid:3f5739f8-4344-4ce5-9f85-9bda224b41d7</ualterms:fedora3uuid>
   <dcterms:title>Circumpolar Photographs</dcterms:title>
   <dcterms:creator>Administrator admin</dcterms:creator>
   <dcterms:description/>
@@ -100,8 +100,8 @@
 <foxml:datastreamVersion ID="DC.2" LABEL="Circumpolar Digital Image Collection" CREATED="2011-11-14T22:17:48.055Z" MIMETYPE="text/xml" FORMAT_URI="http://www.openarchives.org/OAI/2.0/oai_dc/">
 <foxml:xmlContent>
 <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
-  <ualterms:fedora3uuid xmlns:ualterms="http://terms.library.library.ca" xsi:type="string">uuid:3f5739f8-4344-4ce5-9f85-9bda224b41d7</ualterms:fedora3uuid>
-  <ualterms:fedora3handle xmlns:ualterms="http://terms.library.library.ca" xsi:type="anyURI">http://hdl.handle.net/10402/era.17512</ualterms:fedora3handle>
+  <ualterms:fedora3uuid xmlns:ualterms="http://terms.library.ualberta.ca" xsi:type="string">uuid:3f5739f8-4344-4ce5-9f85-9bda224b41d7</ualterms:fedora3uuid>
+  <ualterms:fedora3handle xmlns:ualterms="http://terms.library.ualberta.ca" xsi:type="anyURI">http://hdl.handle.net/10402/era.17512</ualterms:fedora3handle>
   <dcterms:title>Circumpolar Digital Image Collection</dcterms:title>
   <dcterms:creator>Administrator admin</dcterms:creator>
   <dcterms:description>The Circumpolar Digital Image Collection is a collection of photos, slides, other images and contributions shared by many of the University of Alberta’s polar researchers. Images in the collection may be used for teaching and research purposes. For any other use, please contact the Canadian Circumpolar Institute.</dcterms:description>
@@ -247,7 +247,7 @@
 <foxml:datastream CONTROL_GROUP="X" ID="DCQ" STATE="A" VERSIONABLE="true">
   <foxml:datastreamVersion ID="DCQ.0" LABEL="Item Metadata" MIMETYPE="text/xml">
   <foxml:xmlContent>
-  <dc xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ualterms="http://terms.library.library.ca" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <dc xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ualterms="http://terms.library.ualberta.ca" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <ualterms:fedora3uuid xsi:type="string">uuid:3f5739f8-4344-4ce5-9f85-9bda224b41d7</ualterms:fedora3uuid>
   <ualterms:fedora3handle xsi:type="anyURI">http://hdl.handle.net/10402/era.17512</ualterms:fedora3handle>
   <dcterms:title>Circumpolar Digital Image Collection</dcterms:title>

--- a/spec/fixtures/migration/test-metadata/community/cci.xml
+++ b/spec/fixtures/migration/test-metadata/community/cci.xml
@@ -107,14 +107,14 @@
 <foxml:xmlContent>
 <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
   <dcterms:title>Canadian Circumpolar Institute</dcterms:title>
-  <ualterms:fedora3uuid xmlns:ualterms="http://terms.library.library.ca" xsi:type="string">uuid:d04b3b74-211d-4939-9660-c390958fa2ee</ualterms:fedora3uuid>
+  <ualterms:fedora3uuid xmlns:ualterms="http://terms.library.ualberta.ca" xsi:type="string">uuid:d04b3b74-211d-4939-9660-c390958fa2ee</ualterms:fedora3uuid>
 </oai_dc:dc>
 </foxml:xmlContent>
 </foxml:datastreamVersion>
 <foxml:datastreamVersion ID="DC.1" LABEL="Canadian Circumpolar Institute" CREATED="2010-02-19T15:35:16.076Z" MIMETYPE="text/xml" FORMAT_URI="http://www.openarchives.org/OAI/2.0/oai_dc/" SIZE="727">
 <foxml:xmlContent>
 <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
-  <ualterms:fedora3uuid xmlns:ualterms="http://terms.library.library.ca" xsi:type="string">uuid:d04b3b74-211d-4939-9660-c390958fa2ee</ualterms:fedora3uuid>
+  <ualterms:fedora3uuid xmlns:ualterms="http://terms.library.ualberta.ca" xsi:type="string">uuid:d04b3b74-211d-4939-9660-c390958fa2ee</ualterms:fedora3uuid>
   <dcterms:title>Canadian Circumpolar Institute</dcterms:title>
   <dcterms:creator>Administrator admin</dcterms:creator>
   <dcterms:description>The Canadian Circumpolar Institute is an interdisciplinary centre dedicated to promoting, facilitating and conducting research of the highest caliber throughout the circumpolar world. We strive to develop an institute that will contribute to effective decision making, assist in the development of sustainable communities, and advance the understanding of circumpolar regions generally.</dcterms:description>
@@ -124,8 +124,8 @@
 <foxml:datastreamVersion ID="DC.2" LABEL="Canadian Circumpolar Institute" CREATED="2013-09-20T19:45:30.028Z" MIMETYPE="text/xml" FORMAT_URI="http://www.openarchives.org/OAI/2.0/oai_dc/">
 <foxml:xmlContent>
 <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
-  <ualterms:fedora3uuid xmlns:ualterms="http://terms.library.library.ca" xsi:type="string">uuid:d04b3b74-211d-4939-9660-c390958fa2ee</ualterms:fedora3uuid>
-  <ualterms:fedora3handle xmlns:ualterms="http://terms.library.library.ca" xsi:type="anyURI">http://hdl.handle.net/10402/era.17144</ualterms:fedora3handle>
+  <ualterms:fedora3uuid xmlns:ualterms="http://terms.library.ualberta.ca" xsi:type="string">uuid:d04b3b74-211d-4939-9660-c390958fa2ee</ualterms:fedora3uuid>
+  <ualterms:fedora3handle xmlns:ualterms="http://terms.library.ualberta.ca" xsi:type="anyURI">http://hdl.handle.net/10402/era.17144</ualterms:fedora3handle>
   <dcterms:title>Canadian Circumpolar Institute</dcterms:title>
   <dcterms:creator>Administrator admin</dcterms:creator>
   <dcterms:description>The Canadian Circumpolar Institute is an interdisciplinary centre dedicated to promoting, facilitating and conducting research of the highest caliber throughout the circumpolar world. We strive to develop an institute that will contribute to effective decision making, assist in the development of sustainable communities, and advance the understanding of circumpolar regions generally.</dcterms:description>
@@ -346,7 +346,7 @@
 <foxml:datastream CONTROL_GROUP="X" ID="DCQ" STATE="A" VERSIONABLE="true">
   <foxml:datastreamVersion ID="DCQ.0" LABEL="Item Metadata" MIMETYPE="text/xml">
   <foxml:xmlContent>
-  <dc xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ualterms="http://terms.library.library.ca" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <dc xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ualterms="http://terms.library.ualberta.ca" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <ualterms:fedora3uuid xsi:type="string">uuid:d04b3b74-211d-4939-9660-c390958fa2ee</ualterms:fedora3uuid>
   <ualterms:fedora3handle xsi:type="anyURI">http://hdl.handle.net/10402/era.17144</ualterms:fedora3handle>
   <dcterms:title>Canadian Circumpolar Institute</dcterms:title>

--- a/spec/fixtures/migration/test-metadata/multifile-metadata/uuid_multifile.xml
+++ b/spec/fixtures/migration/test-metadata/multifile-metadata/uuid_multifile.xml
@@ -581,7 +581,7 @@
       <foxml:xmlContent>
         <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
           <dcterms:title>Suncor Steepbank Mine Project Application</dcterms:title>
-          <ualterms:fedora3uuid xmlns:ualterms="http://terms.library.library.ca" xsi:type="string">uuid:846f544d-94db-41b4-9f4a-654e1457ed8c</ualterms:fedora3uuid>
+          <ualterms:fedora3uuid xmlns:ualterms="http://terms.library.ualberta.ca" xsi:type="string">uuid:846f544d-94db-41b4-9f4a-654e1457ed8c</ualterms:fedora3uuid>
         </oai_dc:dc>
       </foxml:xmlContent>
     </foxml:datastreamVersion>
@@ -1933,7 +1933,7 @@
   <foxml:datastream CONTROL_GROUP="X" ID="DCQ" STATE="A" VERSIONABLE="true">
   <foxml:datastreamVersion CREATED="2014-06-27T15:33:13.762Z" ID="DCQ.10" LABEL="Item Metadata" MIMETYPE="text/xml">
       <foxml:xmlContent>
-        <dc xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ualterms="http://terms.library.library.ca">
+        <dc xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ualterms="http://terms.library.ualberta.ca">
           <dcterms:creator>Suncor Inc., Oil Sands Group</dcterms:creator>
           <dcterms:description>Suncor Inc. is applying for regulatory approval to proceed with the development of the proposed Steepbank Mine, to be located across the Athabasca River from its current operations near Fort McMurray in the Regional Municipality of Wood Buffalo in northeastern Alberta. In April1995 a disclosure document was released for the proposed mine. Since then, a comprehensive public and regulatory consultation and communication program and an environmental impact assessment have been underway in parallel with engineering feasibility studies. This document comprises the Application for Approval of Steepbank Mine and serves to meet the requirements under the Alberta Oil Sands Conservation Act, the Alberta Environmental Protection and Enhancement Act and the Alberta Water Resources Act. It also includes the Environmental Impact Assessment. This folder contains the main volumes of the EIA plus the supporting reports. Look at the Subject List at the left to see the Volume/Report titles then click on the applicable link on the right.</dcterms:description>
           <dcterms:format xsi:type="dcterms:IMT">application/pdf</dcterms:format>

--- a/spec/fixtures/migration/test-metadata/standard-metadata/uuid_standard.xml
+++ b/spec/fixtures/migration/test-metadata/standard-metadata/uuid_standard.xml
@@ -117,7 +117,7 @@
       <foxml:xmlContent>
         <oai_dc:dc xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
           <dcterms:title>Bison sculpture at the entrance to the USGS Ice Core Lab</dcterms:title>
-          <ualterms:fedora3uuid xmlns:ualterms="http://terms.library.library.ca" xsi:type="string">uuid:394266f0-0e4a-42e6-a199-158165226426</ualterms:fedora3uuid>
+          <ualterms:fedora3uuid xmlns:ualterms="http://terms.library.ualberta.ca" xsi:type="string">uuid:394266f0-0e4a-42e6-a199-158165226426</ualterms:fedora3uuid>
         </oai_dc:dc>
       </foxml:xmlContent>
     </foxml:datastreamVersion>
@@ -360,7 +360,7 @@
   <foxml:datastream CONTROL_GROUP="X" ID="DCQ" STATE="A" VERSIONABLE="true">
   <foxml:datastreamVersion CREATED="2013-03-05T18:21:20.211Z" ID="DCQ.1" LABEL="Item Metadata" MIMETYPE="text/xml">
       <foxml:xmlContent>
-        <dc xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ualterms="http://terms.library.library.ca">
+        <dc xmlns:dcterms="http://purl.org/dc/terms/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:ualterms="http://terms.library.ualberta.ca">
           <dcterms:creator>Campbell, Sandy</dcterms:creator>
           <dcterms:format xsi:type="dcterms:IMT">image/pjpeg</dcterms:format>
           <dcterms:language xsi:type="dcterms:ISO639-3">eng</dcterms:language>


### PR DESCRIPTION
This fixes a typo in my previous PR for fixing the UATerms namespace. 
It should be merged only when John's new sample Dataverse metadata set is ready, so that the metadata and the code are in sync.