### PR TITLE
Migrate without datastreams

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Batch ingest
 - **migration:era_collection_community** which migrates collections and communities in the metadata directory use (run community migration first then collection migration): ```rake migration:era_collection_community['lib/tasks/migration/test-metadata/community']```
 ```rake migration:era_collection_community['lib/tasks/migration/test-metadata/collection']```
 - **migration:eraitem** which migrates active/non-deleted items from the metadata directory (argument from the rake task) use: ```rake migration:eraitem['lib/tasks/migration/test-metadata']```
+  - to load the metadata without the content datastreams use: ```rake migration:eraitem['lib/tasks/migration/test-metadata',false]```
   - **note: migration has to happen in the following order: communities, collections, then eraitems.**
   - **note: file name should start with "uuid_", only those files will be selected.**
 - ```rake hydranorth:update_special_itemtype``` will update the resource type "report" to "computing science technical report" if this item is a member of "technical report". In order for the rake task to work, the collection has to be migrated already and exist in the system.

--- a/lib/tasks/migration.rake
+++ b/lib/tasks/migration.rake
@@ -398,7 +398,7 @@ namespace :migration do
       #get the relsext metadata
       relsext_version = metadata.xpath("//foxml:datastreamVersion[contains(@ID, 'RELS-EXT.')]//rdf:Description",NS).last
       collections = relsext_version.xpath("memberof:isMemberOfCollection/@rdf:resource", NS).map{ |node| node.value.split("/")[1] }
-      community = relsext_version.xpath("memberof:isMemberOf/@rdf:resource", NS).map {|node| node.value.split("/")[1] }
+      communities = relsext_version.xpath("memberof:isMemberOf/@rdf:resource", NS).map {|node| node.value.split("/")[1] }
       user = relsext_version.at_xpath("userns:userId", NS).text() if relsext_version.at_xpath("userns:userId", NS)
       submitter = relsext_version.at_xpath("userns:submitterId", NS).text() if relsext_version.at_xpath("userns:submitterId", NS)
 
@@ -528,14 +528,18 @@ namespace :migration do
 
       MigrationLogger.info "Generic File saved id:#{@generic_file.id}"	  
       MigrationLogger.info "Generic File created id:#{@generic_file.id}"
-      MigrationLogger.info "Add file to collection #{collections}and community #{community} if needed"
+      MigrationLogger.info "Add file to collection #{collections} and community #{communities} if needed"
       collection_noids = []
       if !collections.empty?
         collections.each do |c|
-	  collection_noids << add_to_collection(@generic_file, c)
-	end
+      	  collection_noids << add_to_collection(@generic_file, c)
+      	end
       else
-        collection_noids << add_to_collection(@generic_file, community)
+        if !communities.empty?
+          communities.each do |c|
+            collection_noids << add_to_collection(@generic_file, c)
+          end
+        end
       end
       collection_noids.each do |c|
         @generic_file.hasCollection = [Collection.find(c).title]


### PR DESCRIPTION
- enable the eraitem task to skip the import of content datastreams, so as to allow faster testing of the migration of metadata.
- handle items with multiple communities, by treating community as an array, in the same way as we do collections.

Closes #572 
