### PR TITLE
Remove clamav to improve performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ services:
   - redis-server
 before_install:
   - sudo apt-get update
-  - sudo apt-get install libclamav-dev clamav-freshclam
-  - sudo freshclam
+# clamav installation copied from https://github.com/postmodern/ffi-clamav/blob/master/.travis.yml
+  - sudo apt-get install libclamav-dev clamav-data
 before_script:
   - redis-cli info
   - bundle exec rake jetty:start


### PR DESCRIPTION
This uses the same Travis config as the ffi-clamav project does. It saves about five minutes (23 instead of 28) and runs all our tests.