### PR TITLE
temporarily remove the function to add more than one group collection…

### DIFF
--- a/app/views/batch/_add_to_collections.html.erb
+++ b/app/views/batch/_add_to_collections.html.erb
@@ -34,7 +34,7 @@
       <%= f.collection_select :hasCollectionId, @user_collections, :id, :title, {:include_blank => true}, {:name => "generic_file[hasCollectionId][]", :class => 'form-control collection-select community-group-1' } %>
       </div>
      </div>
-      <button type="button" class="btn btn-success add_collection_group"><i class="icon-white glyphicon-plus"></i><span>Add to More Communities/Collections</span></button>
+<!--      <button type="button" class="btn btn-success add_collection_group"><i class="icon-white glyphicon-plus"></i><span>Add to More Communities/Collections</span></button> -->
     </div>
   </div>
 </div>


### PR DESCRIPTION
…/community

This is to temporarily disable the function of adding more than one group of community/collection, as it needs some javascript work from @nnunn 