### PR TITLE
Migration: sort files, add completion log message

### DIFF
--- a/lib/tasks/migration.rake
+++ b/lib/tasks/migration.rake
@@ -216,10 +216,15 @@ namespace :migration do
     @ingest_batch = Batch.find_or_create(@ingest_batch_id)
     MigrationLogger.info "Ingest Batch ID #{@ingest_batch_id}"
     #for each metadata file in the migration directory
-    Dir.glob(metadata_dir+"/uuid_*.xml").sort.each do |file|
+    allfiles = Dir.glob(metadata_dir+"/uuid_*.xml")
+    filecount = allfiles.select { |file| File.file?(file) }.count
+    MigrationLogger.info "Files to process: " + filecount.to_s
+    thisfile = 1
+    allfiles.sort.each do |file|
     begin
       start_time = Time.now
-      MigrationLogger.info "Processing the file #{file}"
+      MigrationLogger.info "Processing the file #{file} (#{thisfile} of #{filecount})"
+      thisfile = thisfile + 1
       #reading the metadata file
       metadata = Nokogiri::XML(File.open(file))
 

--- a/lib/tasks/migration.rake
+++ b/lib/tasks/migration.rake
@@ -219,12 +219,10 @@ namespace :migration do
     allfiles = Dir.glob(metadata_dir+"/uuid_*.xml")
     filecount = allfiles.select { |file| File.file?(file) }.count
     MigrationLogger.info "Files to process: " + filecount.to_s
-    thisfile = 1
-    allfiles.sort.each do |file|
+    allfiles.sort.each_with_index do |file, thisfile|
     begin
       start_time = Time.now
-      MigrationLogger.info "Processing the file #{file} (#{thisfile} of #{filecount})"
-      thisfile = thisfile + 1
+      MigrationLogger.info "Processing the file #{file} (#{thisfile + 1} of #{filecount})"
       #reading the metadata file
       metadata = Nokogiri::XML(File.open(file))
 

--- a/lib/tasks/migration.rake
+++ b/lib/tasks/migration.rake
@@ -216,7 +216,7 @@ namespace :migration do
     @ingest_batch = Batch.find_or_create(@ingest_batch_id)
     MigrationLogger.info "Ingest Batch ID #{@ingest_batch_id}"
     #for each metadata file in the migration directory
-    Dir.glob(metadata_dir+"/uuid_*.xml") do |file|
+    Dir.glob(metadata_dir+"/uuid_*.xml").sort.each do |file|
     begin
       start_time = Time.now
       MigrationLogger.info "Processing the file #{file}"
@@ -602,7 +602,7 @@ namespace :migration do
       end
       # remove the file from temp location
       if migrated && incollections
-        MigrationLogger.info "file migrated successfully"
+        MigrationLogger.info "COMPLETED #{uuid} from #{file} as #{@generic_file.id} in collections #{collections} and communities #{communities}"
         #move metadata to success location
         #FileUtils.mv(file, "#{COMPLETED_DIR}/#{File.basename(file)}")
       end


### PR DESCRIPTION
Added a couple of tweaks to improve the logging of the big migration:

- sort the files, so they are processed in alphabetical order
- add file counter to log message ("file 104 of 903")
- add a completion entry that gives the uuid, file path and name, NOID, and communities and collections, so that we can grep out complete info

This should make it easier to monitor and if necessary restart the migration.