### PR TITLE
add proper 404ing of items and clean up 404 page style

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,10 @@
 class ApplicationController < ActionController::Base
-  # Adds a few additional behaviors into the application controller 
+  # Adds a few additional behaviors into the application controller
   include Blacklight::Controller
-  # Adds Sufia behaviors into the application controller 
+  # Adds Sufia behaviors into the application controller
   include Sufia::Controller
-  # Please be sure to impelement current_user and user_session. Blacklight depends on 
-  # these methods in order to perform user specific actions. 
+  # Please be sure to impelement current_user and user_session. Blacklight depends on
+  # these methods in order to perform user specific actions.
 
   layout 'sufia-one-column'
 
@@ -12,8 +12,11 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
-  before_filter :force_account_link, 
+  before_filter :force_account_link,
                 if: -> { @current_user && @current_user.link_pending? }
+
+  rescue_from ActiveFedora::ObjectNotFoundError, with: -> { render_404 ActiveFedora::ObjectNotFoundError }
+  rescue_from ActiveRecord::RecordNotFound, with: -> { render_404 ActiveRecord::RecordNotFound }
 
 
   def after_sign_in_path_for(resource)

--- a/app/views/error/404.html.erb
+++ b/app/views/error/404.html.erb
@@ -1,0 +1,6 @@
+<h1>Not Found</h1>
+
+<p> The item you are looking for is not currently available in ERA. We are
+migrating our collections and it will take a few days for all the items to
+appear. Please contact us at erahelp@ualberta.ca if you would like more
+information about this migration.</p>

--- a/app/views/layouts/error.html.erb
+++ b/app/views/layouts/error.html.erb
@@ -1,34 +1,26 @@
 <!DOCTYPE html>
-<html lang="<%= t("sufia.document_language") %>">
+<html lang="<%= t("sufia.document_language") %>" prefix="og:http://ogp.me/ns#">
   <head>
-    <meta charset="utf-8" />
-
-    <title><%= h(application_name) %>: System Error</title>
-    <!-- application css -->
-    <%= stylesheet_link_tag 'application' %>
-
-    <!-- application js -->
-    <%= javascript_include_tag 'application' %>
-
-    <%= render partial: '/ga', formats: [:html] %>
+    <%= render partial: 'layouts/head_tag_content' %>
   </head>
-
-<body>
-<div  id="wrapper">
-  <div class="container-fluid">
-    <div id="page-positioner">
-      <%= render partial: '/masthead', formats: [:html] %>
-      <div id="content-wrapper">
-        <div id="content" class="row">
-            <div class="col-sm-8 col-md-8 col-lg-8">
+  <body>
+    <div class="wrap">
+      <div class="container-fluid tan">
+        <%= render partial: '/masthead' %>
+      </div>
+      <div class="container-fluid">
+        <div class="container main">
+          <div id="content" class="row">
+            <%= render partial: '/flash_msg' %>
+            <div class="col-xs-12">
               <%= yield %>
             </div>
-        </div><!-- /#content -->
-      </div><!-- /#content-wrapper -->
-      <%= render partial: '/footer' %>
-    </div><!-- /#page-positioner -->
-  </div><!-- /.container -->
-</div><!-- /#wrapper -->
-</body>
-
+          </div>
+        </div>
+      </div>
+      <div class="push"></div>
+    </div>
+    <%= render partial: '/footer' %>
+    <%= render 'shared/ajax_modal' %>
+  </body>
 </html>


### PR DESCRIPTION
Adds proper 404ing for missing files, and cleans up the 404 page to match current styling. Looks as below, with wording provided by @sfbetz. New wording will be needed once the migration is complete:

![404](https://cloud.githubusercontent.com/assets/51773/10295590/dbc79460-6b7e-11e5-974c-f31ca2e9e9f0.PNG)
