### PR TITLE
removing total_items improves performance for large collections fixes…

### DIFF
--- a/app/presenters/hydranorth/collection_presenter.rb
+++ b/app/presenters/hydranorth/collection_presenter.rb
@@ -3,9 +3,9 @@ class Hydranorth::CollectionPresenter < Hydranorth::Presenter
 
   self.model_class = ::Collection
   # Terms is the list of fields displayed by app/views/collections/_show_descriptions.html.erb
-  #temporarily remove size from the view to reduce loading time
+  #temporarily remove size and total_items from the view to reduce loading time
 
-  self.terms = [:title, :total_items, :description, :creator,
+  self.terms = [:title, :description, :creator,
                 :date_created]
 
   # Depositor and permissions are not displayed in app/views/collections/_show_descriptions.html.erb

--- a/db/performance_data.rb
+++ b/db/performance_data.rb
@@ -1,0 +1,25 @@
+northern = Collection.find(title: "Northern North America Collection").first
+northern ||= Collection.new.tap do |c|
+  c.apply_depositor_metadata "eraadmi@ualberta.ca" 
+  c.creator = ["eraadmi@ualberta.ca"]
+  c.title = "Northern North America Collection"
+  c.description = "These images were donated to the University of Alberta by Dr. Joel Martin Halpern, a prominent anthropologist who did extensive work in the northern parts of North America." 
+  c.fedora3uuid = "uuid:f1fc4163-ee06-4347-a387-2f430b140643"
+  c.is_official = true
+  c.save!
+end
+
+files = []
+
+if 0 == northern.members.count
+  1132.times do |i|
+    print '*' 
+    file = GenericFile.create do |gf| 
+      gf.apply_depositor_metadata('eraadmi@ualberta.ca')
+      gf.read_groups = ['public']
+    end
+    files << file
+  end
+  northern.members << files
+  northern.save!
+end

--- a/spec/controllers/collections_controller_perf_spec.rb
+++ b/spec/controllers/collections_controller_perf_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+require 'performance_helper'
+require 'benchmark'
+
+describe CollectionsController, :type => :controller, slow: true do
+  routes { Hydra::Collections::Engine.routes }
+
+
+  context "index performance" do
+
+    it 'should be fast' do
+      expect( Benchmark.realtime{
+        get :index
+      }).to be < 0.5
+    end
+
+  end
+
+end

--- a/spec/performance_helper.rb
+++ b/spec/performance_helper.rb
@@ -1,0 +1,8 @@
+RSpec.configure do |config|
+  config.use_transactional_fixtures = true
+    
+  #seed the database before the test suite runs
+  config.before(:suite) do
+    load "#{Rails.root}/db/performance_data.rb"
+  end
+end


### PR DESCRIPTION
… #692

exclude long running test using: rspec --tag ~slow spec
only long running test using: rspec --tag slow spec