### PR TITLE
Duplicate CCID/Accounts Fix. Closes #693.

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -236,7 +236,12 @@ Devise.setup do |config|
   config.omniauth :shibboleth, {
     :uid_field => 'uid',
     :info_fields => {:name => 'givenName', :last_name => 'sn'}
-  }
+  } unless Rails.env.development?
+
+  config.omniauth :shibboleth, {
+    :uid_field => ->(request) {request.call('uid') || request.call('eppn').gsub(/@.*/, '')},
+    :info_fields => {:name => 'givenName', :last_name => 'sn'}
+  } if Rails.env.development?
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -25,7 +25,7 @@ FactoryGirl.define do
     end
 
     factory :testshib do
-      email 'myself@testshib.org'
+      email 'myself@ualberta.ca'
     end
 
     factory :archivist, aliases: [:user_with_fixtures] do


### PR DESCRIPTION
Cleans up confirmation logic, makes shibboleth work across TestShib and IST providers, normalizes TestShib responses to match those sent by IST, makes tests consistent with IST responses, and fixes an issue with duplicate users being created in some scenarios.