### PR TITLE
701 ccid after embargo

### DIFF
--- a/app/controllers/concerns/hydranorth/batch_controller_behavior.rb
+++ b/app/controllers/concerns/hydranorth/batch_controller_behavior.rb
@@ -37,7 +37,8 @@ module Hydranorth
         add_to_collection
       end
       file_attributes = Hydranorth::Forms::BatchEditForm.model_attributes(params[:generic_file])
-      Sufia.queue.push(BatchUpdateJob.new(current_user.user_key, params[:id], params[:title], params[:trid], params[:ser], file_attributes, params[:visibility]))
+      Sufia.queue.push(BatchUpdateJob.new(current_user.user_key, params[:id], params[:title], params[:trid], params[:ser], file_attributes, params[:visibility], params[:embargo_release_date], params[:visibility_during_embargo],
+                  params[:visibility_after_embargo]))
       flash[:notice] = 'Your files are being processed by ' + t('sufia.product_name') + ' in the background. The metadata and access controls you specified are being applied. Files will be marked <span class="label label-danger" title="Private">Private</span> until this process is complete (shouldn\'t take too long, hang in there!). You may need to refresh your dashboard to see these updates.'
       if uploading_on_behalf_of? @batch
         redirect_to sufia.dashboard_shares_path

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,7 +13,7 @@ module ApplicationHelper
         options.delete_at(0)
         options.reverse!
       when :loosen
-        options.delete_at(2)
+        options.delete_at(3)
     end
     return options
   end

--- a/app/models/concerns/hydranorth/access_controls/embargoable.rb
+++ b/app/models/concerns/hydranorth/access_controls/embargoable.rb
@@ -1,0 +1,17 @@
+module Hydranorth
+  module AccessControls
+    module Embargoable
+      extend ActiveSupport::Concern
+      include Hydra::AccessControls::Embargoable
+
+      included do
+        alias_method_chain :visibility, :embargo
+      end
+
+      def visibility_with_embargo
+        return Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO if under_embargo?
+        return visibility_without_embargo
+      end
+    end
+  end
+end

--- a/app/models/concerns/hydranorth/access_controls/institutional_visibility.rb
+++ b/app/models/concerns/hydranorth/access_controls/institutional_visibility.rb
@@ -2,7 +2,7 @@ module Hydranorth
   module AccessControls
     module InstitutionalVisibility
       extend ActiveSupport::Concern
-      include Hydra::AccessControls::Embargoable
+      include Hydranorth::AccessControls::Embargoable
 
       INSTITUTIONAL_PROVIDER_MAPPING = YAML.load(File.read('config/institutional_providers.yml'))
       INSTITUTIONAL_PROVIDERS = INSTITUTIONAL_PROVIDER_MAPPING.values
@@ -22,7 +22,7 @@ module Hydranorth
         alias :institutional_access? :institutional_visibility?
       end
 
-      def visibility_with_institutions=(value)
+      def visibility_with_institutions=(value) 
         return (self.visibility_without_institutions = value) unless INSTITUTIONAL_PROVIDERS.include? value
         return set_institutional_visibility!(value)
       end

--- a/config/initializers/sufia.rb
+++ b/config/initializers/sufia.rb
@@ -288,6 +288,8 @@ module SufiaHelper
       content_tag :span, t('sufia.visibility.registered'), class: "label label-info", title: 'Authenticated Access'
     elsif document.public?
       content_tag :span, t('sufia.visibility.open'), class: "label label-success", title: t('sufia.visibility.open_title_attr')
+    elsif document.embargoed?
+      content_tag :span, 'Embargo', class:"label label-warning", title: 'Embargo'
     else
       content_tag :span, t('sufia.visibility.private'), class: "label label-danger", title: t('sufia.visibility.private_title_attr')
     end
@@ -301,6 +303,10 @@ module Sufia
     module Readable
       def institutional_access?
         (read_groups & Hydranorth::AccessControls::InstitutionalVisibility::INSTITUTIONAL_PROVIDERS).present?
+      end
+
+      def embargoed?
+        self.respond_to?(:under_embargo?) && self.under_embargo?
       end
     end
   end

--- a/spec/features/edit_file_spec.rb
+++ b/spec/features/edit_file_spec.rb
@@ -1,32 +1,48 @@
 require 'spec_helper'
 
-describe 'edit file', :type => :feature do
+describe GenericFile do
+  context 'edit form', :type => :feature do
 
-  let(:user) { FactoryGirl.create :user_with_fixtures }
-  let!(:file) do
-    GenericFile.new.tap do |f|
-      f.title = ['little_file.txt']
-      f.creator = ['little_file.txt_creator']
-      f.resource_type = ["stuff" ]
-      f.read_groups = ['public']
-      f.apply_depositor_metadata(user.user_key)
-      f.save!
+    let(:user) { FactoryGirl.create :user_with_fixtures }
+    let!(:file) do
+      GenericFile.new.tap do |f|
+        f.title = ['little_file.txt']
+        f.creator = ['little_file.txt_creator']
+        f.resource_type = ["stuff" ]
+        f.read_groups = ['public']
+        f.apply_depositor_metadata(user.user_key)
+        f.save!
+      end
     end
-  end
 
-  after :all do
-    cleanup_jetty
-  end
-
-  before do 
-    sign_in user 
-    visit "/dashboard/files"
-    within("#document_#{file.id}") do
-      click_button "Select an action"
-      click_link "Edit File"
+    after :all do
+      cleanup_jetty
     end
-  end
-  
-  it { expect(page).to have_select('generic_file_language', with_options: ['No linguistic content']) }
 
+    before :each do 
+      sign_in user 
+      visit "/dashboard/files"
+      within("#document_#{file.id}") do
+        click_button "Select an action"
+        click_link "Edit File"
+      end
+    end
+    
+    it "should have a 'no linguistic content' option for language" do 
+      expect(page).to have_select('generic_file_language', with_options: ['No linguistic content']) 
+    end
+
+    it "should allow for setting an embargo with CCID protected after embargo state" do
+      click_link 'Permissions'
+      choose 'visibility_embargo'
+      select 'Private', from: 'visibility_during_embargo'
+      select 'University of Alberta', from: 'visibility_after_embargo'
+      fill_in 'embargo_release_date', with: '2020-01-01' 
+      click_button 'Save'
+      visit "/files/#{file.id}"
+      expect(page).to have_content "Embargo"
+      expect(file.reload).to be_under_embargo
+    end
+
+  end
 end


### PR DESCRIPTION
This fixes issues with embargoable in batch uploads and displaying the embargo label properly on forms and in the interface (closing #495), as well as allowing items to come out of embago CCID protected (closing #701)

FYI @pgwillia and @weiweishi since I know you were both looking into this as well.

There is one issue remaining coming out of this: embargoed items will show their "during embargo" status on index pages (typically this means they will show a private label on the index), but when viewed or edited they will correctly show the embargo label. In my opinion we could merge this now and treat that as a separate, lower priority bug to be fixed after the current release cut.