### PR TITLE
Add fresh hard-coded item type counts for front page

### DIFF
--- a/app/assets/javascripts/custom.js
+++ b/app/assets/javascripts/custom.js
@@ -85,12 +85,12 @@ $(document).ready(function(){
 				indexLabelPlacement: "outside",
 		       type: "doughnut",
 		       dataPoints: [
-		       {  y: 1255, indexLabel: "Reports" },
-		       {  y: 1073, indexLabel: "Journal Articles" },
-		       {  y: 288, indexLabel: "Research Materials" },
-		       {  y: 85, indexLabel: "Reviews" },
-		       {  y: 123, indexLabel: "Other" }
-       			]
+			{indexLabel: "Report", y: 9136},
+			{indexLabel: "Image", y: 5416},
+			{indexLabel: "Thesis", y: 5021 + 12255},
+			{indexLabel: "Journal Article (Published)", y: 1706},
+			{indexLabel: "Other", y: 542 + 350 + 310 + 247 + 206 + 184}
+]
      		}
      	]
    });

--- a/app/views/layouts/homepage.html.erb
+++ b/app/views/layouts/homepage.html.erb
@@ -65,7 +65,7 @@
         </div>
         <div class="col-sm-5 white second-row">
 
-          <div class="chart"><h3>ERA currently has more than <strong>24,420</strong> items</h3>
+          <div class="chart"><h3>ERA currently has more than <strong>36,675</strong> items</h3>
          
         <div id="chartContainer">
 


### PR DESCRIPTION
As a first step to #664, these numbers reflect the current state of migration plus the legacy theses.