### PR TITLE
fix ccid permissions #717

### DIFF
--- a/app/models/concerns/hydranorth/access_controls/institutional_visibility.rb
+++ b/app/models/concerns/hydranorth/access_controls/institutional_visibility.rb
@@ -34,8 +34,8 @@ module Hydranorth
       private
 
       def set_institutional_visibility!(institution)
-        # institutional visibility is a subset of registered visibility
-        registered_visibility!
+        # institutional visibility is a subset of public visibility
+        public_visibility!
         set_read_groups([institution],[])
       end
 

--- a/lib/tasks/migration.rake
+++ b/lib/tasks/migration.rake
@@ -984,5 +984,36 @@ namespace :migration do
       end
     end
   end
+  desc "Update ccid-protected items' visibility by uuid in a file. Each line in the file must include a uuid."
+  task "update_ccid_visiblity", [:file_name] => :environment do |cmd, args|
+    file_name = args[:file_name]
+    abort "Must provide a file name to read the uuids" if file_name == nil
+    puts "Processing file #{file_name}"
+    File.readlines(file_name).each do |line|
+      uuid = line.chomp
+      unless uuid.empty?
+
+        solr_rsp =  ActiveFedora::SolrService.instance.conn.get 'select', :params => {:q => Solrizer.solr_name('fedora3uuid')+':'+uuid}
+        numFound = solr_rsp['response']['numFound']
+        if numFound == 0
+          MigrationLogger.error "Item not found by uuid: #{uuid}"
+        elsif numFound > 1
+          MigrationLogger.error "More than one item found by uuid: #{uuid}"
+        else
+          o = solr_rsp['response']['docs'].first
+          object_id = o['id']
+          object_model = o['has_model_ssim'].first
+          if object_model == "Collection"
+            MigrationLogger.error "This object #{object_id} is a Collection and it needs review"
+          elsif object_model == "GenericFile"
+            file = GenericFile.find(object_id)
+            file.visibility = Hydranorth::AccessControls::InstitutionalVisibility::UNIVERSITY_OF_ALBERTA
+            file.save
+            puts "updated visibility for #{uuid} - #{object_id}"
+          end
+        end
+      end
+    end
+  end
 
 end

--- a/spec/fixtures/migration/uuids_ccid_visibility
+++ b/spec/fixtures/migration/uuids_ccid_visibility
@@ -1,0 +1,1 @@
+uuid:db49c90d-2788-4930-a71b-43fecc1b8bbd

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -80,6 +80,7 @@ describe Ability, :type => :model do
     it { is_expected.not_to be_able_to(:update, ContentBlock) }
 
     it {is_expected.not_to be_able_to(:download, restricted_file) }
+    it { is_expected.to be_able_to :read, institutionally_restricted_file}
     it {is_expected.not_to be_able_to(:download, institutionally_restricted_file) }
   end
 
@@ -107,6 +108,7 @@ describe Ability, :type => :model do
     it { is_expected.not_to be_able_to(:update, ContentBlock) }
 
     it {is_expected.to be_able_to(:download, restricted_file) }
+    it { is_expected.to be_able_to :read, institutionally_restricted_file}
     it {is_expected.not_to be_able_to(:download, institutionally_restricted_file) }
   end
 
@@ -115,7 +117,9 @@ describe Ability, :type => :model do
     subject { Ability.new(ccid_user) }
 
     it {is_expected.to be_able_to(:download, restricted_file) }
-    it {is_expected.to be_able_to(:download, institutionally_restricted_file) }
+
+    it { is_expected.to be_able_to :read, institutionally_restricted_file}
+    it { is_expected.to be_able_to(:download, institutionally_restricted_file) }
   end
 
   describe "a user in the admin group" do
@@ -153,6 +157,8 @@ describe Ability, :type => :model do
     it { is_expected.to be_able_to(:update, ContentBlock) }
 
     it {is_expected.to be_able_to(:download, restricted_file) }
+    
+    it { is_expected.to be_able_to :read, institutionally_restricted_file}
     it {is_expected.to be_able_to(:download, institutionally_restricted_file) }
 
   end

--- a/spec/models/institutional_visibility_spec.rb
+++ b/spec/models/institutional_visibility_spec.rb
@@ -20,7 +20,7 @@ describe Hydranorth::AccessControls::InstitutionalVisibility, :type => :model do
     expect { subject.visibility = Hydranorth::AccessControls::InstitutionalVisibility::UNIVERSITY_OF_ALBERTA }.not_to raise_error
     expect(subject.institutional_visibility?).to be true
     expect(subject.read_groups).to include Hydranorth::AccessControls::InstitutionalVisibility::UNIVERSITY_OF_ALBERTA
-    expect(subject.read_groups).to include Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED
+    expect(subject.read_groups).to include Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC
   end
 
   it 'should not continue to list an institution as a read group when set to open visibility' do

--- a/spec/tasks/migration_rake_spec.rb
+++ b/spec/tasks/migration_rake_spec.rb
@@ -370,7 +370,7 @@ describe "Migration rake tasks" do
     subject { @file }
 
     it "item should have private visibility" do
-      expect(subject.visibility).to eq "restricted"
+      expect(subject.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO 
       expect(subject.institutional_visibility?).to be false
       expect(subject.visibility_after_embargo).to eq "open"
       expect(subject.embargo_release_date).to eq "Tues, 30 Nov 2162 07:00:00 +0000"
@@ -411,7 +411,7 @@ describe "Migration rake tasks" do
     subject { @file }
 
     it "item should have private visibility" do
-      expect(subject.visibility).to eq "restricted"
+      expect(subject.visibility).to eq Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_EMBARGO
       expect(subject.institutional_visibility?).to be false
       expect(subject.visibility_after_embargo).to eq "university_of_alberta"
       expect(subject.embargo_release_date).to eq "Mon, 01 Jan 2114 07:00:00 +0000"


### PR DESCRIPTION
fix to institutional visibility to allow the metadata to be opened to public, but control the access at the download level. 
added rake task to update migrated items with correct visibility. 
