### PR TITLE
fix extraneous '>' on /deposit page

### DIFF
--- a/app/views/pages/deposit.html.erb
+++ b/app/views/pages/deposit.html.erb
@@ -51,7 +51,7 @@ Please review our Policies [link] page before beginning a deposit, and ensure th
 
 Note that there are three ways to determine if a journal article can be deposited in ERA and in what form:
 
-	<li>SHERPA/RoMEO: provides information about journal policies for archiving articles in institutional repositories <a href="http://www.sherpa.ac.uk/romeo">http://www.sherpa.ac.uk/romeo></a></li>
+	<li>SHERPA/RoMEO: provides information about journal policies for archiving articles in institutional repositories <a href="http://www.sherpa.ac.uk/romeo">http://www.sherpa.ac.uk/romeo</a></li>
 	<li>Journal websites: many journals state their archiving policies on their website (see sections on author information or copyright)</li>
 	<li>Ask the journal: use an author addendum and/or send an email request to retain your right to deposit your work in an institutional repository (e.g., the SPARC Canadian Author Addendum <a href="http://www.carl-abrc.ca/uploads/SCC/Addendum_updated-e.pdf">http://www.carl-abrc.ca/uploads/SCC/Addendum_updated-e.pdf</a> )</li>
 </ul>


### PR DESCRIPTION
There's no associated bug for this that I'm aware of, I just happened to notice a small typo on the /deposit page