### PR TITLE
fix to rake task that clear expired embargo

### DIFF
--- a/lib/tasks/hydranorth.rake
+++ b/lib/tasks/hydranorth.rake
@@ -11,6 +11,7 @@ namespace :hydranorth do
     items = Hydra::EmbargoService.assets_with_expired_embargoes
     items.each do |item|
       item.embargo_visibility!
+      item.embargo.save!
       item.save!
     end
   end

--- a/spec/support/shared_contexts/rake.rb
+++ b/spec/support/shared_contexts/rake.rb
@@ -1,0 +1,20 @@
+require "rake"
+
+shared_context "rake" do
+  let(:rake) 		{ Rake::Application.new }
+  let(:task_name)	{ self.class.top_level_description }
+  let(:task_path) 	{ "lib/tasks/#{task_name.split(":").first}" }
+  subject		{ rake[task_name] }
+
+
+  def loaded_files_excluding_current_rake_file
+    $".reject {|file| file == Rails.root.join("#{task_path}.rake").to_s }
+  end
+
+  before do
+    Rake.application = rake
+    Rake.application.rake_require(task_path, [Rails.root.to_s], loaded_files_excluding_current_rake_file)
+
+    Rake::Task.define_task(:environment)
+  end
+end

--- a/spec/tasks/hydranorth_rake_spec.rb
+++ b/spec/tasks/hydranorth_rake_spec.rb
@@ -3,7 +3,6 @@ require 'support/shared_contexts/rake'
 
 describe "hydranorth:remove_lapsed_embargoes" do
   include_context "rake"
-  byebug
   let(:past_date) { 2.days.ago }
   let!(:file) do
     FactoryGirl.build(:generic_file, title: ["tested embargo"], embargo_release_date: past_date.to_s, visibility_after_embargo: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, visibility_during_embargo: Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE).tap do |work|
@@ -20,7 +19,6 @@ describe "hydranorth:remove_lapsed_embargoes" do
   it "clears the expired embargo" do
     subject.invoke
     object = GenericFile.find(file.id)
-    byebug
     expect(object).not_to be_nil
     expect(object.embargo_release_date).to be_nil
     expect(object.embargo_history).not_to be_empty


### PR DESCRIPTION
Due to an upstream bug?/behavior, embargoes are not saved automatically with the object, unless they are saved explicitly. This is to fix the rake task, and update the spec task to better handle rake task tests. part of #732 #830 
 