### PR TITLE
Migration embargoes

### DIFF
--- a/lib/tasks/dataverse_migration.rake
+++ b/lib/tasks/dataverse_migration.rake
@@ -1,27 +1,6 @@
 require 'fileutils'
 require './lib/tasks/migration/migration_logger'
 
-
-  NS = {
-        "xmlns:xsi"=>"http://www.w3.org/2001/XMLSchema-instance", 
-        "xmlns:dc"=>"http://purl.org/dc/elements/1.1/", 
-        "xmlns:dcterms"=>"http://purl.org/dc/terms/", 
-        "xmlns:georss"=>"http://www.georss.org/georss/",
-        "xmlns:oai_dc"=>"http://www.openarchives.org/OAI/2.0/oai_dc/", 
-        "xmlns:ualterms"=>"http://terms.library.ualberta.ca", 
-    }
-
-
-  #report directory
-  REPORTS = "lib/tasks/migration/reports/"
-  #Oddities report
-  ODDITIES = REPORTS+ "dataverse_oddities.txt"
-  #verification error report
-  VERIFICATION_ERROR = REPORTS + "dataverse_verification_errors.txt"
-  #item migration list
-  ITEM_LIST = REPORTS + "dataverse_item_list.txt"
-  FileUtils::mkdir_p REPORTS 
-
 namespace :migration do
 	
   desc "batch migrate object metadata from Dataverse' OAI-DC"

--- a/lib/tasks/migration.rake
+++ b/lib/tasks/migration.rake
@@ -568,16 +568,16 @@ namespace :migration do
       @generic_file.title = [title]
       file_attributes = {"resource_type"=>[type], "contributor"=>contributors, "description"=>[description], "date_created"=>date, "year_created"=>year_created, "license"=>license, "rights"=>rights, "subject"=>subjects, "spatial"=>spatials, "temporal"=>temporals, "language"=>LANG.fetch(language), "fedora3uuid"=>uuid, "fedora3handle" => fedora3handle, "trid" => trid, "ser" => ser, "abstract" => abstract, "date_accepted" => date_accepted, "date_submitted" => date_submitted, "is_version_of" => is_version_of, "graduation_date" => graduation_date, "specialization" => specialization, "supervisor" => supervisors, "committee_member" => committee_members, "department" => departments, "thesis_name" => thesis_name, "thesis_level" => thesis_level, "alternative_title" => alternative_titles, "proquest" => proquest, "unicorn" => unicorn, "degree_grantor" => degree_grantor, "dissertant" => dissertant,  "ingestbatch" => @ingest_batch_id, "belongsToCommunity" => communities_noid, "hasCollectionId" => collections_noid, "hasCollection" => collections_title}
       @generic_file.attributes = file_attributes
-
       if item_state == 'Inactive'
         if embargoed
-          @generic_file.embargo_release_date = DateTime.strptime(embargoed_date, '%Y-%m-%dT%H:%M:%S.%N%Z')
-          @generic_file.visibility_during_embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+          embargo_release_date = DateTime.strptime(embargoed_date, '%Y-%m-%dT%H:%M:%S.%N%Z')
+          visibility_during_embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
           if ccid_protected
-            @generic_file.visibility_after_embargo = Hydranorth::AccessControls::InstitutionalVisibility::UNIVERSITY_OF_ALBERTA
+            visibility_after_embargo = Hydranorth::AccessControls::InstitutionalVisibility::UNIVERSITY_OF_ALBERTA
           else
-            @generic_file.visibility_after_embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+            visibility_after_embargo = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
           end
+          @generic_file.apply_embargo(embargo_release_date, visibility_during_embargo, visibility_after_embargo)
         else
            @generic_file.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
         end

--- a/lib/tasks/migration.rake
+++ b/lib/tasks/migration.rake
@@ -604,7 +604,6 @@ namespace :migration do
       attr_t = Time.now
       attr_time = attr_time + (attr_t - metadata_t)
       puts "Set attributes for the file used #{attr_t - metadata_t}"
-
       MigrationLogger.info "Generic File attribute set id:#{@generic_file.id}"
 
       # save the file
@@ -894,10 +893,11 @@ namespace :migration do
 
   def find_collection(uuid)
     # translate old post-2009 thesis collection
-    if uuid == 'uuid:7af76c0f-61d6-4ebc-a2aa-79c125480269'
+    if uuid == 'uuid:7af76c0f-61d6-4ebc-a2aa-79c125480269' and ENV["RAILS_ENV"] == "production"
       id = THESES_ID
     else
-      solr_rsp = ActiveFedora::SolrService.instance.conn.get "select", :params => {:q => Solrizer.solr_name('fedora3uuid')+':'+uuid.to_s}
+      uuid_id = uuid.split(":")[1]
+      solr_rsp = ActiveFedora::SolrService.instance.conn.get "select", :params => {:q => Solrizer.solr_name('fedora3uuid')+':'+uuid_id.to_s}
       numFound = solr_rsp['response']['numFound']
       if numFound == 1
         id = solr_rsp['response']['docs'].first['id']

--- a/lib/tasks/migration_audit.rake
+++ b/lib/tasks/migration_audit.rake
@@ -3,50 +3,7 @@ require './lib/tasks/migration/audit_logger'
 require 'pdf-reader'
 require 'builder'
 
-  NS = {
-        "xmlns:xsi"=>"http://www.w3.org/2001/XMLSchema-instance",
-        "xmlns:foxml"=>"info:fedora/fedora-system:def/foxml#",
-        "xmlns:audit"=>"info:fedora/fedora-system:def/audit#",
-        "xmlns:dc"=>"http://purl.org/dc/elements/1.1/",
-        "xmlns:dcterms"=>"http://purl.org/dc/terms/",
-        "xmlns:georss"=>"http://www.georss.org/georss/",
-        "xmlns:oai_dc"=>"http://www.openarchives.org/OAI/2.0/oai_dc/",
-        "xmlns:ualterms"=>"http://terms.library.ualberta.ca",
-        "memberof"=>"info:fedora/fedora-system:def/relations-external#",
-        "hasmodel"=>"info:fedora/fedora-system:def/model#",
-        "xmlns:rdf"=>"http://www.w3.org/1999/02/22-rdf-syntax-ns#",
-        "userns"=>"http://era.library.ualberta.ca/schema/definitions.xsd#",
-        "xmlns:marcrel"=>"http://id.loc.gov/vocabulary/relators",
-        "xmlns:vivo"=>"http://vivoweb.org/ontology/core",
-        "xmlns:bibo"=>"http://purl.org/ontology/bibo/"
-    }
-
-
-  LANG = {
-      "eng" => "English",
-      "en" => "English",
-      "en_US" => "English",
-      "fre" => "French",
-      "spa" => "Spanish",
-      "chi" => "Chinese",
-      "ger" => "German",
-      "ita" => "Italian",
-      "rus" => "Russian",
-      "ukr" => "Ukrainian",
-      "jpn" => "Japanese",
-      "zxx" => "No linguistic content",
-      "other" => "Other",
-      ""    => "No linguistic content",
-  }
-
-  #Use the ERA public interface to download original file and foxml
-  FEDORA_URL = "http://thesisdeposit.library.ualberta.ca:8180/fedora/get/"
-  #temporary location for file download
-  TEMP = "lib/tasks/migration/tmp"
-  FILE_STORE = "lib/tasks/migration/files"
   FileUtils::mkdir_p TEMP
-  #set the thesis collection ID
-  THESES_ID = '44558t416'
 
 namespace :migration do
 

--- a/spec/tasks/migration_rake_spec.rb
+++ b/spec/tasks/migration_rake_spec.rb
@@ -5,6 +5,7 @@ describe "Migration rake tasks" do
   before do
     load File.expand_path("../../../lib/tasks/migration.rake", __FILE__)
   end
+
   describe "migration:eraitem - standard item" do
     before do
       Collection.delete_all
@@ -143,6 +144,7 @@ describe "Migration rake tasks" do
         c.fedora3uuid = 'uuid:7af76c0f-61d6-4ebc-a2aa-79c125480269'
         c.save
       end
+      GenericFile.delete_all
       Rake::Task.define_task(:environment)
       Rake::Task["migration:eraitem"].invoke('spec/fixtures/migration/test-metadata/thesis-metadata')
       result = ActiveFedora::SolrService.instance.conn.get "select", params: {q:["fedora3uuid_tesim:uuid:0b19d1f5-399a-42b4-be0c-360010ef6784"]}
@@ -175,13 +177,14 @@ describe "Migration rake tasks" do
       expect(subject.content.latest_version.label).to eq "version1"
       expect(subject.fedora3foxml.latest_version.label).to eq "version1"
       expect(subject.license).to eq "I am required to use/link to a publisher's license"
-      expect(subject.rights).to eq "Permission is hereby granted to the University of Alberta Libraries to reproduce single copies of this thesis and to lend or sell such copies for private, scholarly or scientific research purposes only. Where the thesis is converted to, or otherwise made available in digital form, the University of Alberta will advise potential users of the thesis of these terms. The author reserves all other publication and other rights in association with the copyright in the thesis and, except as herein before provided, neither the thesis nor any substantial portion thereof may be printed or otherwise reproduced in any material form whatsoever without the author's prior written permission."
+      expect(subject.rights).to eq "Permission is hereby granted to the University of Alberta Libraries to reproduce single copies of this thesis and to lend or sell such copies for private, scholarly or scientific research purposes only. The author reserves all other publication and other rights in association with the copyright in the thesis and, except as herein before provided, neither the thesis nor any substantial portion thereof may be printed or otherwise reproduced in any material form whatsoever without the author's prior written permission."
       expect(subject.hasCollection).to include 'Theses'
       expect(subject.hasCollectionId).to include @collection.id
       expect(subject.belongsToCommunity).to include @community.id
 
     end
   end
+
   describe "migration:eraitem - legacy thesis" do
     before do
       Collection.delete_all
@@ -472,5 +475,4 @@ describe "Migration rake tasks" do
       expect(subject.read_groups).to include Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC
     end
   end
-
 end


### PR DESCRIPTION
This PR is put in place to deal with migrating embargoes theses. 
* it uses apply_embargo during migration so it will automatically removed expired embargoes
* uses Open3 to run system curl commands to pass proper http authentication
* it removes duplicated constants defined in rake tasks
