### PR TITLE
Audit script tweaks for visibility checking

### DIFF
--- a/lib/tasks/migration_audit.rake
+++ b/lib/tasks/migration_audit.rake
@@ -761,10 +761,10 @@ namespace :migration do
            end
          else
            if ccid_protected
-             if @generic_file.visibility != Hydranorth::AccessControls::InstitutionalVisibility::UNIVERSITY_OF_ALBERTA
-               AuditLogger.info "visibility: #{@generic_file.visibility}^#{Hydranorth::AccessControls::InstitutionalVisibility::UNIVERSITY_OF_ALBERTA}"
-	       	   xml.visibility {
-	           xml.object_ @generic_file.visibility
+             if @generic_file.read_groups != [Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, Hydranorth::AccessControls::InstitutionalVisibility::UNIVERSITY_OF_ALBERTA]
+               AuditLogger.info "visibility|read_groups: #{@generic_file.read_groups}^#{Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, Hydranorth::AccessControls::InstitutionalVisibility::UNIVERSITY_OF_ALBERTA}"
+	       	   xml.read_groups {
+	           xml.object_ @generic_file.read_groups
 	           xml.xml_ Hydranorth::AccessControls::InstitutionalVisibility::UNIVERSITY_OF_ALBERTA
 	           }
              end

--- a/lib/tasks/migration_audit.rake
+++ b/lib/tasks/migration_audit.rake
@@ -719,7 +719,7 @@ namespace :migration do
          else
            if ccid_protected
              if @generic_file.read_groups != [Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, Hydranorth::AccessControls::InstitutionalVisibility::UNIVERSITY_OF_ALBERTA]
-               AuditLogger.info "visibility|read_groups: #{@generic_file.read_groups}^#{Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC, Hydranorth::AccessControls::InstitutionalVisibility::UNIVERSITY_OF_ALBERTA}"
+               AuditLogger.info "visibility|read_groups: #{@generic_file.read_groups}^#{Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC}^#{Hydranorth::AccessControls::InstitutionalVisibility::UNIVERSITY_OF_ALBERTA}"
 	       	   xml.read_groups {
 	           xml.object_ @generic_file.read_groups
 	           xml.xml_ Hydranorth::AccessControls::InstitutionalVisibility::UNIVERSITY_OF_ALBERTA


### PR DESCRIPTION
This is a tweak to fix the visibility checking in audit script. As all ccid-protected objects have "open" for their visibility, and use "read_groups" to control the download, read_groups should be the information the audit script is checking.  

