### PR TITLE
Closes #837

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -24,7 +24,7 @@ class CatalogController < ApplicationController
 
   def self.date_created_field
     value = solr_name('date_created', :stored_sortable, type: :string)
-    logger.debug "SOLR_SORT_DATE#{value}" 
+    logger.debug "SOLR_SORT_DATE#{value}"
     return value
   end
 
@@ -59,7 +59,7 @@ class CatalogController < ApplicationController
         all_names = config.show_fields.values.map{|val| val.field}.join(" ")
         title_name = Solrizer.solr_name("title", :stored_searchable)
         field.solr_parameters = {
-         qf: "#{all_names} noid_tsi file_format_tesim all_text_timv",
+         qf: "#{all_names} id file_format_tesim all_text_timv supervisor_tesim department_tesim committee_member_tesim",
           pf: "#{title_name}"
         }
       end
@@ -185,8 +185,8 @@ class CatalogController < ApplicationController
     config.add_facet_field solr_name("creator", :facetable), label: "Author", limit: 3
     config.add_facet_field solr_name("subject", :facetable), label: "Subject", limit: 3
     config.add_facet_field solr_name("language", :facetable), label: "Language", limit: 3
-    config.add_facet_field solr_name("hasCollection", :symbol), label: "Collection", limit: 3 
-    config.add_facet_field solr_name("year_created", :facetable), label: "Year", limit: 3 
+    config.add_facet_field solr_name("hasCollection", :symbol), label: "Collection", limit: 3
+    config.add_facet_field solr_name("year_created", :facetable), label: "Year", limit: 3
     # publisher: has "show: false", but is needed to provide field label in "You searched for" box
     config.add_facet_field solr_name("publisher", :facetable), label: "Publisher", show: false
 

--- a/app/models/generic_file.rb
+++ b/app/models/generic_file.rb
@@ -8,6 +8,11 @@ class GenericFile < ActiveFedora::Base
   include Hydranorth::GenericFile::DOI
   include Hydranorth::GenericFile::Era1Stats
 
+  # override the default indexer from Sufia
+  def self.indexer
+    Hydranorth::GenericFileIndexingService
+  end
+
   # work around for ActiveFedora logic
   # that mapped activetriples to collection names
   # on persisted collection relationships
@@ -21,6 +26,18 @@ class GenericFile < ActiveFedora::Base
         ActiveFedora::Base.from_uri(member_activetriple.id, nil).title
       end
     end
+  end
+
+  def thesis?
+    self.resource_type.include? Sufia.config.special_types['thesis']
+  end
+
+  def ser?
+    self.resource_type.include? Sufia.config.special_types['ser']
+  end
+
+  def cstr?
+    self.resource_type.include? Sufia.config.special_types['cstr']
   end
 
 end

--- a/app/services/hydranorth/generic_file_indexing_service.rb
+++ b/app/services/hydranorth/generic_file_indexing_service.rb
@@ -1,0 +1,11 @@
+class Hydranorth::GenericFileIndexingService <  Sufia::GenericFileIndexingService
+
+  def generate_solr_document
+    super.tap do |solr_doc|
+      if object.thesis?
+        solr_doc[Solrizer.solr_name('creator')] = object.dissertant
+        solr_doc[Solrizer.solr_name('description')] = object.abstract
+      end
+    end
+  end
+end


### PR DESCRIPTION
Indexes Thesis dissertant and abstract field into the creator and description fields, respectively. Also adds NOID, department, supervisor, and committee_member fields into the general keyword search.

BONUS -- speeds up the Catalogue controller tests significantly (from ~5 minutes down to 30 seconds, on my machine).