### PR TITLE
Fixes #904

### DIFF
--- a/app/views/_front_search_form.html.erb
+++ b/app/views/_front_search_form.html.erb
@@ -13,6 +13,6 @@
        </div> 
         <div class="row">
           <div class="col-md-12 more-info" id="browse">
-           <h4>Browse <a href="communities">communities</a>, <a href="browse">subjects</a>, or <a href="browse">item types</a></h4>
+           <h4>Browse <a href="/communities">communities</a>, <a href="/browse">subjects</a>, or <a href="/browse">item types</a></h4>
           </div>
         </div>


### PR DESCRIPTION
Add initial slashes to internal links in mobile search form, to prevent Google crawling urls with final "/browse" or "/communities".