### PR TITLE
Resolves multiple collection issues and closes #913

### DIFF
--- a/app/controllers/concerns/hydranorth/batch_edits_controller_behavior.rb
+++ b/app/controllers/concerns/hydranorth/batch_edits_controller_behavior.rb
@@ -11,10 +11,13 @@ module Hydranorth
         redirect_to sufia.dashboard_index_path
       end
     end
+
     protected
+
     def terms
       Hydranorth::Forms::BatchEditForm.terms
     end
+
     def generic_file_params
       Hydranorth::Forms::BatchEditForm.model_attributes(params[:generic_file])
     end

--- a/app/controllers/concerns/hydranorth/collections/selects_collections.rb
+++ b/app/controllers/concerns/hydranorth/collections/selects_collections.rb
@@ -4,6 +4,12 @@ module Hydranorth::Collections::SelectsCollections
   include Hydra::Collections::SelectsCollections
   include Hydranorth::Permissions
 
+
+
+  def collections_search_builder_class
+    ::CollectionSearchBuilder
+  end
+
   def access_levels
     { read: [:read, :edit], edit: [:edit] }
   end
@@ -16,7 +22,7 @@ module Hydranorth::Collections::SelectsCollections
     find_communities(:edit)
   end
 
- # need to check for _tesim and _bsi in solr query because ActiveFedora does not allow false to be passed 
+ # need to check for _tesim and _bsi in solr query because ActiveFedora does not allow false to be passed
  def find_collections(access_level = nil)
     # need to know the user if there is an access level applied otherwise we are just doing public collections
     authenticate_user! unless access_level.blank?
@@ -25,12 +31,11 @@ module Hydranorth::Collections::SelectsCollections
     query = collections_search_builder(access_level).with({q: '(-is_community_bsi:true AND -is_community_tesim:true) AND (is_official_bsi:true OR is_official_tesim:true)'}).query
     response = repository.search(query)
     # return the user's collections (or public collections if no access_level is applied)
-    # not a fan of sorting this in ruby, but collections search builder doesn't seem to pass on
-    # sort params properly
- 
-    # return the user's collections (or public collections if no access_level is applied)
-    @user_collections = response.documents
- end   
+
+   @user_collections = response.documents.sort do |d1, d2|
+     d1.title <=> d2.title
+   end
+ end
 
  # need to check for _tesim and _bsi in solr query because ActiveFedora does not allow false to be passed
  def find_communities(access_level = nil)

--- a/app/helpers/generic_file_helper.rb
+++ b/app/helpers/generic_file_helper.rb
@@ -35,7 +35,7 @@ module GenericFileHelper
   end
 
   def render_collection_list(gf)
-    if gf.respond_to? :hasCollection
+    if gf.respond_to?(:hasCollection) && gf.hasCollectionId.present?
       ("Is part of: " + gf.hasCollection.each_with_index.map { |title, i| link_to(title, collections.collection_path(gf.hasCollectionId[i])) }.join(", ")).html_safe
     end
   end

--- a/app/models/collection_search_builder.rb
+++ b/app/models/collection_search_builder.rb
@@ -1,0 +1,7 @@
+class CollectionSearchBuilder < Hydra::Collections::SearchBuilder
+  # raise the default limit on solr results so that we don't
+  # truncate the number of returned collections accidently
+  def some_rows(solr_parameters)
+    solr_parameters[:rows] = '1000'
+  end
+end

--- a/app/models/generic_file.rb
+++ b/app/models/generic_file.rb
@@ -28,6 +28,15 @@ class GenericFile < ActiveFedora::Base
     end
   end
 
+  def hasCollectionId=(arr)
+    # when clearing hasCollectionId, we must also ensure
+    # hasCollection stays in sync
+    if arr.empty?
+      self.hasCollection = []
+    end
+    super(arr)
+  end
+
   def thesis?
     self.resource_type.include? Sufia.config.special_types['thesis']
   end


### PR DESCRIPTION
* when an item belongs to a community but has no collection, community index pages no longer crash
* when hasCollectionId is cleared, also clear hasCollection so that there is no inconsistency left in the metadata
* sorts the collections in the edit generic file collection drop-down
* raises the limit on the number of collections returned from the solr search populating @user_collections