### PR TITLE
947 ci failing tests

### DIFF
--- a/lib/tasks/spec.rake
+++ b/lib/tasks/spec.rake
@@ -3,6 +3,11 @@ require 'ci/reporter/rake/rspec'
 
 REPORT_PATH = "spec/reports"
 
-RSpec::Core::RakeTask.new(:spec)
+RSpec::Core::RakeTask.new(:spec, :tag) do |t, task_args|
+  t.rspec_opts = "--tag #{task_args[:tag]}" unless task_args[:tag].nil?
+end
 
-task :spec => 'ci:setup:rspec'
+RSpec::Core::RakeTask.new(:cispec) do |t|
+  t.rspec_opts = "--tag ~integration"
+end
+task :cispec => 'ci:setup:rspec'

--- a/spec/forms/generic_file_new_form_spec.rb
+++ b/spec/forms/generic_file_new_form_spec.rb
@@ -26,6 +26,7 @@ describe 'generic file new', :type => :feature do
   describe 'new item fields', js: true, :integration => true do
     before do
       visit '/'
+      Capybara.default_max_wait_time = 30
     end
     it "should not allow multiple resource_type selections, but assign to an array" do
       sign_in user
@@ -35,7 +36,6 @@ describe 'generic file new', :type => :feature do
         attach_file "files[]", [fixture_path + '/world.png']
         click_button('main_upload_start')
       end
-      sleep(30)
       expect(page).to have_xpath('//select[@name="generic_file[resource_type][]" and not(@multiple)]')
     end
   end
@@ -51,7 +51,6 @@ describe 'generic file new', :type => :feature do
       check('terms_of_service')
       attach_file "files[]", [fixture_path + '/world.png']
       click_button('main_upload_start')
-      sleep(30)
       expect(page).to have_field('generic_file_trid')
     end
   end
@@ -68,7 +67,6 @@ describe 'generic file new', :type => :feature do
         page.attach_file "files[]", [fixture_path + '/world.png']
         click_button('main_upload_start')
       end
-      sleep(30)
       within("form#new_generic_file") do
         expect(find_field('Description or Abstract')).to have_content ''
         expect(find_field('Date Created')).to have_content ''

--- a/spec/forms/generic_file_new_form_spec.rb
+++ b/spec/forms/generic_file_new_form_spec.rb
@@ -23,7 +23,7 @@ describe 'generic file new', :type => :feature do
     end
   end
 
-  describe 'new item fields', js: true do
+  describe 'new item fields', js: true, :integration => true do
     before do
       visit '/'
     end
@@ -40,7 +40,7 @@ describe 'generic file new', :type => :feature do
     end
   end
 
-  describe 'request CSTR item', js: true do
+  describe 'request CSTR item', js: true, :integration => true do
     before do
       visit '/'
     end
@@ -56,7 +56,7 @@ describe 'generic file new', :type => :feature do
     end
   end
 
-  describe 'check form fields', js: true do
+  describe 'check form fields', js: true, :integration => true do
     before do
       visit '/'
     end

--- a/spec/jobs/create_derivatives_job_spec.rb
+++ b/spec/jobs/create_derivatives_job_spec.rb
@@ -27,7 +27,7 @@ describe CreateDerivativesJob do
         expect(@generic_file.thumbnail).not_to have_content
       end
 
-      it 'generates a thumbnail on job run' do
+      it 'generates a thumbnail on job run', :integration => true do
         subject.run
         @generic_file.reload
         expect(@generic_file.thumbnail).to have_content

--- a/spec/models/generic_file_spec.rb
+++ b/spec/models/generic_file_spec.rb
@@ -72,7 +72,7 @@ describe GenericFile, :type => :model do
     end
   end
 
-  describe '#append_metadata' do
+  describe '#append_metadata', :integration => true do
 
     before  do
       @myfile = GenericFile.new(id: SecureRandom.hex)

--- a/spec/tasks/migration_rake_spec.rb
+++ b/spec/tasks/migration_rake_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 require 'rake'
 require 'fileutils'
-describe "Migration rake tasks" do
+describe "Migration rake tasks", :integration => true do
   before do
     load File.expand_path("../../../lib/tasks/migration.rake", __FILE__)
   end


### PR DESCRIPTION
16/17 ignored in CI environment because fits and ffmpeg dependencies missing. Created rake task ```rake cispec``` to ignore tests marked integration. Alternately can run ``` rake spec[<tag>]``` where tag is '~integration'.  Can be used to include or exclude a subset of specs. closes #947  