### PR TITLE
deactivate expired embargoes first before changing item's visibility

### DIFF
--- a/lib/tasks/hydranorth.rake
+++ b/lib/tasks/hydranorth.rake
@@ -10,6 +10,7 @@ namespace :hydranorth do
   task :remove_lapsed_embargoes => :environment do |t|
     items = Hydra::EmbargoService.assets_with_expired_embargoes
     items.each do |item|
+      item.deactivate_embargo! if item.embargo_release_date
       item.embargo_visibility!
       item.embargo.save!
       item.save!


### PR DESCRIPTION
items from migration may not have embargoes deactivated properly. They need to be deactivated first to be cleared by the rake task. 