### PR TITLE
Embargo rake logging

### DIFF
--- a/lib/tasks/hydranorth.rake
+++ b/lib/tasks/hydranorth.rake
@@ -9,6 +9,7 @@ namespace :hydranorth do
     RakeLogger.info "********START remove_lapsed_embargoes ********" 
     items = Hydra::EmbargoService.assets_with_expired_embargoes
     RakeLogger.info "Number of items that have expired embargoes: #{items.count}"
+    puts "Number of items that have expired embargoes: #{items.count}"
     count = 0
     items.each do |item|
       RakeLogger.info "clear expired embargo for #{item.id}"
@@ -19,6 +20,7 @@ namespace :hydranorth do
       count = count + 1 if GenericFile.find(item.id).embargo_release_date.nil?
     end
     RakeLogger.info "Number of items which lapsed embargo has been lifted: #{count}"
+    puts "Number of items that have expired embargoes: #{items.count}"
   end
 
   desc "Update Resource Type for selected collections"

--- a/lib/tasks/rake_logger.rb
+++ b/lib/tasks/rake_logger.rb
@@ -1,0 +1,33 @@
+#Custom Rake Task Logger
+require 'singleton'
+
+class RakeLogger < Logger
+  include Singleton
+
+    # Optional, but good for prefixing timestamps automatically
+  class Formatter
+    def call(severity, time, progname, msg)
+      formatted_severity = sprintf("%-5s",severity.to_s)
+      formatted_time = time.strftime("%Y-%m-%d %H:%M:%S")
+      "[#{formatted_severity} #{formatted_time}] #{msg.strip}\n"
+    end
+  end
+
+  def initialize
+    if Rails.env.test?
+      super(Rails.root.join('log/rake_task_spec.log'))
+    else
+      super(Rails.root.join('log/rake_task.log'))
+    end
+    self.formatter = Formatter.new
+    self
+  end
+
+  def self.error(msg); instance.error(msg) end
+  def self.debug(msg); instance.debug(msg) end
+  def self.fatal(msg); instance.fatal(msg) end
+  def self.info(msg); instance.info(msg) end
+  def self.warn(msg); instance.warn(msg) end
+  def self.add(msg); instance.add(msg) end
+  def self.log(msg); instance.log(msg) end
+end


### PR DESCRIPTION
* fix the issue where the lapsed embargo release date from migration is left behind with embargo_visibility! method (fixed the failed spec test from previous PR #978) 
* add proper rake task logger to keep the rake task logging information separated for better monitoring.
