### PR TITLE
Fix triple loading corruption

### DIFF
--- a/app/models/concerns/hydranorth/collection_behavior.rb
+++ b/app/models/concerns/hydranorth/collection_behavior.rb
@@ -159,7 +159,7 @@ module Hydranorth
             end
           end
         else # I'm a collection
-          new_member.set_value(:hasCollection, self) if new_member.respond_to? :hasCollection
+          new_member.set_value(:hasCollection, [self.title]) if new_member.respond_to? :hasCollection
           new_member.set_value(:hasCollectionId, [self.id]) if new_member.respond_to? :hasCollectionId
           new_member.set_value(:belongsToCommunity, self.belongsToCommunity) if self.belongsToCommunity?
         end

--- a/lib/hydranorth/raw_fedora.rb
+++ b/lib/hydranorth/raw_fedora.rb
@@ -1,0 +1,39 @@
+module Hydranorth
+  module RawFedora
+    
+    def get(id, subresource = '', additional_arguments = {})
+      response = perform :get, to_pair_tree(id) + subresource, additional_arguments
+    
+      xml = Nokogiri::XML.parse(response)
+      return response.code, xml
+    end
+    
+    def perform(action, path, arg_hash = {}, request_headers = {})
+      request_headers.reverse_merge!({cache_control: :no_cache})
+      user = ActiveFedora.config.credentials[:user]
+      password = ActiveFedora.config.credentials[:password]
+      endpoint = ActiveFedora.config.credentials[:url] + ActiveFedora.config.credentials[:base_path]
+      
+      url = endpoint + path + stringify_args(arg_hash)
+      
+      RestClient::Request.execute(
+        method: action, 
+        url: url,
+        user: user,
+        password: password,
+        headers: request_headers)
+    end
+    
+    def to_pair_tree(id)
+      "/#{ActiveFedora::Noid.treeify(id).strip}/"
+    end
+    
+    def stringify_args(arg_hash)
+      args = arg_hash.empty? ? '' : '?'
+      arg_hash.each { |k, v| args << k.to_s + '=' + v.to_s }
+      args
+    end
+    
+    module_function :get, :perform, :to_pair_tree, :stringify_args
+  end
+end

--- a/lib/tasks/repair_collections_refs.rake
+++ b/lib/tasks/repair_collections_refs.rake
@@ -1,0 +1,19 @@
+namespace :hydranorth do
+  desc 'Repair objects whose hasCollection property has been replaced with hasCollection_ref'
+  
+  task :repair_collections_refs => :environment do
+    GenericFile.all.each do |file|
+      response, xml = Hydranorth::RawFedora.get(file.id, 'fcr:export', format: 'jcr/xml')
+      next unless response == 200
+      
+      unless xml.xpath('//sv:property[@sv:name="ns002:hasCollection_ref"]').empty?
+        c = Collection.find(file.hasCollectionId.first)
+        
+        # removing and re-adding the file should replace the file's collection_ref
+        # with the actual collection information
+        c.remove_member_id(file.id)
+        c.add_member_ids [file.id]
+      end
+    end
+  end
+end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'rest-client'
 
 describe Collection do
 
@@ -13,7 +14,7 @@ describe Collection do
   end
   let(:another_collection) { FactoryGirl.create(:collection) }
 
-  before do
+  before :each do
     subject.title = 'A title'
     subject.apply_depositor_metadata(user.user_key)
     subject.save
@@ -87,6 +88,16 @@ describe Collection do
     subject.belongsToCommunity = ["adsfsfsd"]
     subject.save
     expect(subject.belongsToCommunity?).to be true
+  end
+
+  it "should not insert a hasCollection_ref instead of hasCollection" do
+    subject.add_member_ids [file.id]
+    response_code, xml = Hydranorth::RawFedora.get(file.id, '/fcr:export', format: 'jcr/xml')
+
+    expect(response_code).to eq 200
+    expect(xml.xpath('//sv:property[@sv:name="ns002:hasCollection"]')).not_to be_empty
+    expect(xml.xpath('//sv:property[@sv:name="ns002:hasCollection_ref"]')).to be_empty
+    expect(xml.xpath('//sv:property[@sv:name="ns002:hasCollection"]').first.inner_text).to eq 'A title'
   end
 
 end


### PR DESCRIPTION
Resolve issue where adding an object to a collection could result in the hasCollection attribute (normally the collection's title) being replaced with a hasCollection_ref that ActiveFedora does not cache and must load from Fedora (potentially multiple times) when loading an object.

Also includes a rake task to repair objects already impacted by this corruption, although the performance of the rake task against the production repository may not be satisfactory -- if anyone knows a better way to enumerate GenericFile Ids in the Fedora repo, we should use that instead of going through ActiveFedora.

Still investigating various means of testing the rake task.

Closes #969