### PR TITLE
Resolve collection select issue when changing communities

### DIFF
--- a/app/assets/javascripts/hydranorth_update_collections.js
+++ b/app/assets/javascripts/hydranorth_update_collections.js
@@ -32,7 +32,7 @@ function update_collections() {
 
 
 $(function() {
-	// ensure collection optionss match selected community on page load
+	// ensure collection options match selected community on page load
 	update_collections();
 	
 	$('#generic_file_belongsToCommunity').change(function() {

--- a/app/assets/javascripts/hydranorth_update_collections.js
+++ b/app/assets/javascripts/hydranorth_update_collections.js
@@ -1,22 +1,43 @@
-$(document).on("ready change", function(){ 
-          if (!($('.community-select').attr('class'))) return;
-          currentClass = $('.community-select').attr('class').split(' ')
-          var index
-          $.each ( currentClass, function(i, v) {
-            if (v.match(/community-group/)) { index = v}
-          });
-          $.ajax({
-            url: 'update_collections',
-            type: 'GET',
-            dataType: 'script',
-            data:  {
-              community_id: $("option:selected", '.community-select').val(),
-              index: index
-            },
-            complete: function() {}, 
-            success: function(data, textStatus, xhr) {
-            },
-            error: function() {}
-           });
+function update_collections() {
+	// TODO I'm not really clear on the necessity of grovelling
+	// through any matching item's class string to find an "index"
+	// here. A custom data attribute would likely be a better choice.
+	// I don't want to delay the bugfix to clean this up, though -- MB
+	if (!($('.community-select').attr('class'))) return;
+	
+	currentClass = $('.community-select').attr('class').split(' ');
+	
+	var index;
+	
+	$.each(currentClass, function(i, v) {
+		
+		if (v.match(/community-group/)) {
+			index = v
+		}
+	});
+	
+	$.ajax({
+		url: 'update_collections',
+		type: 'GET',
+		dataType: 'script',
+		data: {
+			community_id: $("option:selected", '.community-select').val(),
+			index: index
+		},
+		complete: function() {},
+		success: function(data, textStatus, xhr) {},
+		error: function() {}
+	});
+}
 
+
+$(function() {
+	// ensure collection optionss match selected community on page load
+	update_collections();
+	
+	$('#generic_file_belongsToCommunity').change(function() {
+		// Reload collections when the community selection is changed.
+		update_collections();
+	});
 });
+


### PR DESCRIPTION
Fixes an issue where the ajax call to refresh the collection options was running on every page change, instead of only when the community select changes. Further cleanup of this file may be warranted (the index code doesn't seem to serve a purpose, and if it does, should likely leverage a custom data attribute instead), but this doesn't impact the immediate bug. Closes #1012.