### PR TITLE
Only render collections that actually belong to the selected community

### DIFF
--- a/app/assets/javascripts/hydranorth_update_collections.js
+++ b/app/assets/javascripts/hydranorth_update_collections.js
@@ -4,18 +4,18 @@ function update_collections() {
 	// here. A custom data attribute would likely be a better choice.
 	// I don't want to delay the bugfix to clean this up, though -- MB
 	if (!($('.community-select').attr('class'))) return;
-	
+
 	currentClass = $('.community-select').attr('class').split(' ');
-	
+
 	var index;
-	
+
 	$.each(currentClass, function(i, v) {
-		
+
 		if (v.match(/community-group/)) {
 			index = v
 		}
 	});
-	
+
 	$.ajax({
 		url: 'update_collections',
 		type: 'GET',
@@ -32,12 +32,8 @@ function update_collections() {
 
 
 $(function() {
-	// ensure collection options match selected community on page load
-	update_collections();
-	
 	$('#generic_file_belongsToCommunity').change(function() {
 		// Reload collections when the community selection is changed.
 		update_collections();
 	});
 });
-

--- a/app/controllers/concerns/hydranorth/batch_controller_behavior.rb
+++ b/app/controllers/concerns/hydranorth/batch_controller_behavior.rb
@@ -54,7 +54,7 @@ module Hydranorth
 
 
     def update_collections
-      @filtered_collections = find_filtered_collections_sorted 
+      @filtered_collections = collections_for_community(params[:community_id])
       @index = params[:index]
       respond_to do |format|
         format.js {}

--- a/app/controllers/concerns/hydranorth/collections/selects_collections.rb
+++ b/app/controllers/concerns/hydranorth/collections/selects_collections.rb
@@ -5,7 +5,6 @@ module Hydranorth::Collections::SelectsCollections
   include Hydranorth::Permissions
 
 
-
   def collections_search_builder_class
     ::CollectionSearchBuilder
   end
@@ -58,19 +57,18 @@ module Hydranorth::Collections::SelectsCollections
     end
   end
 
-private
   # Sorting by title implemented in hydra-collections v7.0.0 [projecthydra/hydra-collections@e8e57e5] this is a workaround
-  def find_filtered_collections_sorted(access_level = nil)
+  def collections_for_community(community_id, access_level = nil)
     # need to know the user if there is an access level applied otherwise we are just doing public collections
     authenticate_user! unless access_level.blank?
 
     # run the solr query to find the collections
-    query = collections_search_builder(access_level).with({q: "#{Solrizer.solr_name('belongsToCommunity')}:#{params[:community_id]}"}).query
+    query = collections_search_builder(access_level).with({q: "#{Solrizer.solr_name('belongsToCommunity')}:#{community_id}"}).query
     response = repository.search(query)
     # return the user's collections (or public collections if no access_level is applied)
 
-   response.documents.sort do |d1, d2|
+    response.documents.sort do |d1, d2|
      d1.title <=> d2.title
-   end 
+    end
   end
 end

--- a/app/controllers/concerns/hydranorth/files_controller_behavior.rb
+++ b/app/controllers/concerns/hydranorth/files_controller_behavior.rb
@@ -44,6 +44,9 @@ module Hydranorth
     def edit_form
       find_collections_with_read_access
       find_communities_with_read_access
+
+      @community_collections = collections_for_community(@generic_file.belongsToCommunity.first)
+
       if @generic_file[:resource_type].include? Sufia.config.special_types['cstr']
         Hydranorth::Forms::CstrEditForm.new(@generic_file)
       elsif @generic_file[:resource_type].include? Sufia.config.special_types['ser']

--- a/app/controllers/generic_files_controller.rb
+++ b/app/controllers/generic_files_controller.rb
@@ -14,7 +14,7 @@ class GenericFilesController < ApplicationController
 
   # on edit pages required to filter collections based on selected community
   def update_collections
-    @filtered_collections = find_filtered_collections_sorted
+    @filtered_collections = collections_for_community(params[:community_id])
     @index = params[:index]
     respond_to do |format|
       format.js {}

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -28,6 +28,7 @@ class Ability
     def generic_file_abilities
       can :view_share_work, [GenericFile]
       can :create, [GenericFile] if registered_user?
+      can :update_collections, GenericFile
     end
 
     # callback run at download time to check with CanCan whether or not the user

--- a/app/views/batch/_add_to_collections.html.erb
+++ b/app/views/batch/_add_to_collections.html.erb
@@ -6,28 +6,24 @@
 <% registered_perm = f.object.permissions.map { |perm| perm.access if perm.agent_name == "registered"}.compact.first %>
 
 
-  <h3>Add Item to Communities and Collections</h3>
-  <div class="row">
+<h3>Add Item to Communities and Collections</h3>
+<div class="row">
     <div class="col-xs-6">
-      <div class="container-community-group">
+        <div class="container-community-group">
 
-       <div id="community-group-1" class="community-group"> 
-      <%= f.input_label :belongsToCommunity, as: :multi_value, label: "Community" %>
-      <% if (@form[:resource_type].include? Sufia.config.special_types['cstr']) && (@form[:resource_type].include? Sufia.config.special_types['ser']) %>
-        <%= f.collection_select :belongsToCommunity, @user_communities, :id, :title, {:include_blank => true}, {:name => "generic_file[belongsToCommunity][]", :class => 'form-control community-select community-group-1' } %>
-      <% else %>
-        <%= f.collection_select :belongsToCommunity, @user_communities, :id, :title, {:include_blank => true}, {:name => "generic_file[belongsToCommunity][]", :class => 'form-control community-select community-group-1', :required => true} %>
-      <% end %>
-      <%= f.input_label :hasCollectionId, as: :multi_value, label: "Collection" %>
-      <%= f.collection_select :hasCollectionId, @user_collections, :id, :title, {:include_blank => true}, {:name => "generic_file[hasCollectionId][]", :class => 'form-control collection-select community-group-1' } %>
-      </div>
-
-<div id="additional">
-</div>
-   <button type="button" class="btn btn-success add_collection_group"><i class="icon-white glyphicon-plus"></i><span> Add another Community/Collection group</span></button> 
+            <div id="community-group-1" class="community-group">
+                <%= f.input_label :belongsToCommunity, as: :multi_value, label: "Community" %>
+                <% if (@form[:resource_type].include? Sufia.config.special_types['cstr']) && (@form[:resource_type].include? Sufia.config.special_types['ser']) %>
+                    <%= f.collection_select :belongsToCommunity, @user_communities, :id, :title, {:include_blank => true}, {:name => "generic_file[belongsToCommunity][]", :class => 'form-control community-select community-group-1' } %>
+                <% else %>
+                    <%= f.collection_select :belongsToCommunity, @user_communities, :id, :title, {:include_blank => true}, {:name => "generic_file[belongsToCommunity][]", :class => 'form-control community-select community-group-1', :required => true} %>
+                <% end %>
+                <%= f.input_label :hasCollectionId, as: :multi_value, label: "Collection" %>
+                <%= f.collection_select :hasCollectionId, @user_collections, :id, :title, {:include_blank => true}, {:name => "generic_file[hasCollectionId][]", :class => 'form-control collection-select community-group-1' } %>
+            </div>
+        </div>
     </div>
-  </div>
-   <div class="col-xs-5">
-     <p class="help-block">Items must be associated with at least one ERA Community. This association will apply to ALL THE FILES that you just uploaded. You can change individual file associations once the upload process is complete</p>
-   </div>
+    <div class="col-xs-5">
+        <p class="help-block">Items must be associated with at least one ERA Community. This association will apply to ALL THE FILES that you just uploaded. You can change individual file associations once the upload process is complete</p>
+    </div>
 </div>

--- a/app/views/records/edit_fields/_hasCollectionId.html.erb
+++ b/app/views/records/edit_fields/_hasCollectionId.html.erb
@@ -1,1 +1,1 @@
-<%= f.input :hasCollectionId, collection: @user_collections, value_method: :id, label_method: :title, :include_blank => true, input_html: { :name => "generic_file[hasCollectionId][]", :class => 'form-control collection-select community-group-1' } %>
+<%= f.input :hasCollectionId, collection: @community_collections, value_method: :id, label_method: :title, :include_blank => true, input_html: { :name => "generic_file[hasCollectionId][]", :class => 'form-control collection-select community-group-1' } %>


### PR DESCRIPTION
Closes #1016. Eliminates the need for an AJAX call immediately on page load. Also refactors SelectsCollections's logic for finding collections based on a community ID, so that the code is more composable and does not rely on the presence of a particular request parameter.