### PR TITLE
fix rake stats output

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,13 +72,13 @@ gem 'sitemap'
 gem 'noid', '~> 0.8'
 
 group :test do
-  gem "rspec-rails"
   gem "rspec-its"
   gem "ci_reporter_rspec"
 end
 
 group :development, :test do
   gem "byebug"
+  gem "rspec-rails"
   gem "ruby-debug-passenger"
   gem "selenium-webdriver"
   gem "jettywrapper"


### PR DESCRIPTION
Very small tweak to ensure that rspec-rails gem is also available in the development group, so that a ```bundle exec rake stats``` outputs test information that takes into account rspec.