### PR TITLE
850 browse by date

### DIFF
--- a/app/controllers/recent_controller.rb
+++ b/app/controllers/recent_controller.rb
@@ -14,12 +14,14 @@ class RecentController < ApplicationController
     def recent
       params.permit(:year, :month)
       # grab any recent documents
-      (_, @recent_documents) = search_results({q: "#{Solrizer.solr_name('system_create', :stored_sortable, type: :date)}:#{date_range}", sort: sort_field, rows: 100}, search_params_logic)
+      (_, @recent_documents) = search_results({q: "#{Solrizer.solr_name('system_create', :stored_sortable, type: :date)}:#{date_range}", sort: sort_field, rows: 10000}, search_params_logic)
     end
 
     def date_buckets
       solr_rsp = ActiveFedora::SolrService.instance.conn.get "select", :params => {:q => "#{Solrizer.solr_name('read_access_group', :symbol)}:public #{Solrizer.solr_name('active_fedora_model', :stored_sortable)}:GenericFile", 'facet.range' => "#{Solrizer.solr_name('system_create', :stored_sortable, type: :date)}", 'facet.range.gap' => '+1MONTH', 'facet.range.start' => '1906-01-01T00:00:00Z', 'facet.range.end' => 'NOW', :rows => 0, 'facet.mincount' => 1 } 
-      @date_buckets = solr_rsp['facet_counts']['facet_ranges']['system_create_dtsi']['counts']
+      range_counts = solr_rsp['facet_counts']['facet_ranges']['system_create_dtsi']['counts']
+      @date_buckets = {}
+      range_counts.each_slice(2) { |date,count| (@date_buckets[date.slice(0,4)] ||= []) << [date,count] }
     end
 
     def sort_field

--- a/app/controllers/recent_controller.rb
+++ b/app/controllers/recent_controller.rb
@@ -1,0 +1,45 @@
+class RecentController < ApplicationController
+  include Sufia::HomepageController
+  include RecentHelper
+  layout 'sufia-one-column'
+
+  def index
+    super
+    recent
+    date_buckets
+  end
+
+  protected
+  
+    def recent
+      params.permit(:year, :month)
+      # grab any recent documents
+      (_, @recent_documents) = search_results({q: "#{Solrizer.solr_name('system_create', :stored_sortable, type: :date)}:#{date_range}", sort: sort_field, rows: 100}, search_params_logic)
+    end
+
+    def date_buckets
+      solr_rsp = ActiveFedora::SolrService.instance.conn.get "select", :params => {:q => Solrizer.solr_name('read_access_group', :symbol)+':public', 'facet.range' => "#{Solrizer.solr_name('system_create', :stored_sortable, type: :date)}", 'facet.range.gap' => '+1MONTH', 'facet.range.start' => '1906-01-01T00:00:00Z', 'facet.range.end' => 'NOW', :rows => 0 } 
+      @date_buckets = solr_rsp['facet_counts']['facet_ranges']['system_create_dtsi']['counts']
+    end
+
+    def sort_field
+      "#{Solrizer.solr_name('system_create', :stored_sortable, type: :date)} desc"
+    end
+
+    def date_range
+      date_range = '[NOW-14DAYS TO *]'
+      if params[:month].present? && params[:year].present?
+        date = DateTime.parse("#{params[:year]}/#{params[:month]}")
+        date_range = "[#{floor(date, 1.month)} TO #{ceil(date, 1.month)}]"
+      elsif params[:year].present?
+        date = DateTime.new(params[:year].to_i)
+        date_range = "[#{floor(date, 1.year)} TO #{ceil(date, 1.year)}]"
+      elsif params[:month].present?
+        flash[:alert] = 'Please specify a year.'
+      end
+      date_range
+
+    rescue ArgumentError
+      flash[:alert] = "Couldn't interpret the date."
+    end
+end

--- a/app/controllers/recent_controller.rb
+++ b/app/controllers/recent_controller.rb
@@ -18,7 +18,7 @@ class RecentController < ApplicationController
     end
 
     def date_buckets
-      solr_rsp = ActiveFedora::SolrService.instance.conn.get "select", :params => {:q => Solrizer.solr_name('read_access_group', :symbol)+':public', 'facet.range' => "#{Solrizer.solr_name('system_create', :stored_sortable, type: :date)}", 'facet.range.gap' => '+1MONTH', 'facet.range.start' => '1906-01-01T00:00:00Z', 'facet.range.end' => 'NOW', :rows => 0 } 
+      solr_rsp = ActiveFedora::SolrService.instance.conn.get "select", :params => {:q => "#{Solrizer.solr_name('read_access_group', :symbol)}:public #{Solrizer.solr_name('active_fedora_model', :stored_sortable)}:GenericFile", 'facet.range' => "#{Solrizer.solr_name('system_create', :stored_sortable, type: :date)}", 'facet.range.gap' => '+1MONTH', 'facet.range.start' => '1906-01-01T00:00:00Z', 'facet.range.end' => 'NOW', :rows => 0, 'facet.mincount' => 1 } 
       @date_buckets = solr_rsp['facet_counts']['facet_ranges']['system_create_dtsi']['counts']
     end
 

--- a/app/helpers/recent_helper.rb
+++ b/app/helpers/recent_helper.rb
@@ -27,6 +27,10 @@ module RecentHelper
     DateTime.parse(bucket).strftime("%Y: %B")
   end
   
+  def bucket_as_month(bucket)
+    DateTime.parse(bucket).strftime("%B")
+  end
+
   def bucket_as_params(bucket)
     date = DateTime.parse(bucket)
     {:year => date.year, :month => date.month}

--- a/app/helpers/recent_helper.rb
+++ b/app/helpers/recent_helper.rb
@@ -1,0 +1,34 @@
+module RecentHelper
+
+  def floor_as_time(time, seconds=60)
+    Time.at((time.to_f / seconds).round * seconds).utc
+  end
+ 
+  def floor(time, seconds=60)
+    floor_as_time(time, seconds).iso8601
+  end
+
+  def ceil(time, seconds=60)
+    (floor_as_time(time, seconds) + seconds - 1.second).utc.iso8601
+  end
+
+  def recent_title
+    if params[:year] && params[:month]
+      date = DateTime.parse("#{params[:year]}/#{params[:month]}")
+      "Documents from #{date.strftime("%B")} #{date.year}"
+    elsif params[:year]
+      "Documents from #{params[:year]}"
+    else
+      "Recently Uploaded (last two weeks)"
+    end
+  end
+
+  def bucket_as_date(bucket)
+    DateTime.parse(bucket).strftime("%Y: %B")
+  end
+  
+  def bucket_as_params(bucket)
+    date = DateTime.parse(bucket)
+    {:year => date.year, :month => date.month}
+  end
+end

--- a/app/views/homepage/_recent_document.html.erb
+++ b/app/views/homepage/_recent_document.html.erb
@@ -1,0 +1,29 @@
+<div class="main row">
+  <% if recent_document %>
+    <% if display_thumbs %>
+      <div class="col-sm-3">
+        <%= link_to sufia.generic_file_path(recent_document) do %>
+          <%= render_thumbnail_tag recent_document, { width: "100%" } %>
+        <% end %>
+      </div>
+    <% end %>
+    <div class="col-sm-9">
+      <dl>
+        <dt class="sr-only">Title:</dt>
+        <dd><%= link_to truncate(recent_document.title_or_label, length: 28, separator: ' '), sufia.generic_file_path(recent_document), title: recent_document.title_or_label, class: 'title'  %>
+          <% if display_access %>
+             <% if recent_document.registered? %>
+                  <span class="label label-info" title="<%=t('sufia.institution_name') %>"><%=t('sufia.institution_name') %></span>
+              <% elsif recent_document.public? %>
+                  <span class="label label-success">Open Access</span>
+              <% else %>
+                  <span class="label label-danger">Private</span>
+              <% end %>
+          <% end %>
+        </dd>
+        <dt class="sr-only">Author/Creators:</dt>
+        <dd><%= recent_document.creator.html_safe if recent_document.creator.present? %></dd>
+      </dl>
+    </div>
+  <% end %>
+</div>

--- a/app/views/layouts/homepage.html.erb
+++ b/app/views/layouts/homepage.html.erb
@@ -80,8 +80,9 @@
           <div class="technical-info"><p>ERA builds on multi-institutional collaborations around open source technologies. For a full list of technical specifications, <a href="/about">see here</a>.</p></div>
         </div>
         <div class="col-sm-4 dark-tan second-row">
-          <div id="tweets">
-
+          <div id="recent_docs">
+            <h3><a href="recent">Recent Documents</a></h3>
+            <%= render partial: "recent_document", collection: [@recent_documents.first], locals: {display_thumbs: true, display_access: true} %>
           </div>
         </div>
 

--- a/app/views/recent/_recent_document.html.erb
+++ b/app/views/recent/_recent_document.html.erb
@@ -25,7 +25,7 @@
         <dt class="sr-only">Description:</dt>
         <dd><%= recent_document.description.html_safe if recent_document.description %>
         <dt>Author/Creators:</dt>
-        <dd><%= recent_document.creator.html_safe %></dd>
+        <dd><%= recent_document.creator.html_safe if recent_document.creator.present? %></dd>
       </dl>
     </div>
   <% end %>

--- a/app/views/recent/_recent_document.html.erb
+++ b/app/views/recent/_recent_document.html.erb
@@ -1,0 +1,32 @@
+<div class="main row">
+
+  <% if recent_document %>
+    <% if display_thumbs %>
+      <div class="col-sm-3">
+        <%= link_to sufia.generic_file_path(recent_document) do %>
+          <%= render_thumbnail_tag recent_document, { width: "100%" } %>
+        <% end %>
+      </div>
+    <% end %>
+    <div class="col-sm-9">
+      <dl>
+        <dt class="sr-only">Title:</dt>
+        <dd><%= link_to recent_document.title_or_label, sufia.generic_file_path(recent_document), title: recent_document.title_or_label, class: 'title'  %>
+          <% if display_access %>
+             <% if recent_document.registered? %>
+                  <span class="label label-info" title="<%=t('sufia.institution_name') %>"><%=t('sufia.institution_name') %></span>
+              <% elsif recent_document.public? %>
+                  <span class="label label-success">Open Access</span>
+              <% else %>
+                  <span class="label label-danger">Private</span>
+              <% end %>
+          <% end %>
+        </dd>
+        <dt class="sr-only">Description:</dt>
+        <dd><%= recent_document.description.html_safe if recent_document.description %>
+        <dt>Author/Creators:</dt>
+        <dd><%= recent_document.creator.html_safe %></dd>
+      </dl>
+    </div>
+  <% end %>
+</div>

--- a/app/views/recent/index.html.erb
+++ b/app/views/recent/index.html.erb
@@ -6,8 +6,11 @@
   <h1><%= recent_title %></h1>
   <%= render partial: "recent_document", collection: @recent_documents, locals: {display_thumbs: true, display_access: false} %>
   <h1>Older documents</h1>
-  <% @date_buckets.each_slice(2) do |bucket, count| %>
-    <%= link_to bucket_as_date(bucket), recent_path(bucket_as_params(bucket)) %>
+  <% @date_buckets.each do |year, date| %>
+    <div><%= "#{year}: " %>
+    <% date.each do |bucket| %>
+      <%= link_to bucket_as_month(bucket[0]), recent_path(bucket_as_params(bucket[0])) %> 
+    <% end %>
   <% end %>
 </div>
 

--- a/app/views/recent/index.html.erb
+++ b/app/views/recent/index.html.erb
@@ -1,3 +1,7 @@
+<% content_for(:gscholar_meta) do %>
+ <meta name="robots" content="noindex" />
+<% end %>
+
 <div class="col-md-6">
   <h1><%= recent_title %></h1>
   <%= render partial: "recent_document", collection: @recent_documents, locals: {display_thumbs: true, display_access: false} %>

--- a/app/views/recent/index.html.erb
+++ b/app/views/recent/index.html.erb
@@ -1,0 +1,9 @@
+<div class="col-md-6">
+  <h1><%= recent_title %></h1>
+  <%= render partial: "recent_document", collection: @recent_documents, locals: {display_thumbs: true, display_access: false} %>
+  <h1>Older documents</h1>
+  <% @date_buckets.each_slice(2) do |bucket, count| %>
+    <%= link_to bucket_as_date(bucket), recent_path(bucket_as_params(bucket)) %>
+  <% end %>
+</div>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Hydranorth::Application.routes.draw do
   
+  get 'recent/index'
+
   namespace :admin do
   get 'become/index'
   end
@@ -66,6 +68,7 @@ Hydranorth::Application.routes.draw do
   get 'batches/:id/update_collections' => 'batch#update_collections', as: 'update_collections'
   get 'files/:id/update_collections' => 'generic_files#update_collections'
   get 'communities', controller: 'communities', action: :index
+  get 'recent', controller: 'recent', action: :index
 
 
   # This must be the very last route in the file because it has a catch-all route for 404 errors.

--- a/spec/controllers/recent_controller_spec.rb
+++ b/spec/controllers/recent_controller_spec.rb
@@ -1,0 +1,113 @@
+require 'spec_helper'
+
+RSpec.describe RecentController, type: :controller do
+  routes { Rails.application.class.routes }
+
+  describe "GET #index" do
+    before :each do
+      @gf1 = GenericFile.new(title: ['Test Document PDF'], filename: ['test.pdf'], subject: ['rocks'], read_groups: ['public'])
+      @gf1.apply_depositor_metadata('mjg36')
+      @gf1.save
+      @gf2 = GenericFile.new(title: ['Test Private Document'], filename: ['test2.doc'], subject: ['clouds'], contributor: ['Contrib1'], read_groups: ['private'])
+      @gf2.apply_depositor_metadata('mjg36')
+      @gf2.save
+    end
+
+    after :each do
+      cleanup_jetty
+    end
+
+    it "does not include other user's private documents in recent documents" do
+      get :index
+      expect(response).to be_success
+      titles = assigns(:recent_documents).map { |d| d['title_tesim'][0] }
+      expect(titles).to_not include('Test Private Document')
+    end
+
+    it "includes only GenericFile objects in recent documents" do
+      get :index
+      assigns(:recent_documents).each do |doc|
+        expect(doc[Solrizer.solr_name("has_model", :symbol)]).to eql ["GenericFile"]
+      end
+    end
+
+    it 'includes date buckets for crawling' do
+      get :index
+      expect(assigns(:date_buckets)).to eq ["2016-04-01T00:00:00Z", 1]
+    end
+
+    context "with a document not created this second" do
+      before do
+        gw3 = GenericFile.new(title: ['Test 3 Document'], read_groups: ['public'])
+        gw3.apply_depositor_metadata('mjg36')
+        # stubbing to_solr so we know we have something that didn't create in the current second
+        old_to_solr = gw3.method(:to_solr)
+        allow(gw3).to receive(:to_solr) do
+          old_to_solr.call.merge(
+            Solrizer.solr_name('system_create', :stored_sortable, type: :date) => 1.day.ago.iso8601
+          )
+        end
+        gw3.save
+      end
+
+      it "sets recent documents in the right order" do
+        get :index
+        expect(response).to be_success
+        expect(assigns(:recent_documents).length).to be <= 4
+        create_times = assigns(:recent_documents).map { |d| d['system_create_dtsi'] }
+        expect(create_times).to eq create_times.sort.reverse
+      end 
+    end
+
+    context "with a document not created in the last two weeks" do
+      before do
+        gf4 = GenericFile.new(title: ['Test 4 Document'], read_groups: ['public'])
+        gf4.apply_depositor_metadata('mjg36')
+        #stubbing to_solr so we know we have something significantly older
+        old_to_solr = gf4.method(:to_solr)
+        allow(gf4).to receive(:to_solr) do
+          old_to_solr.call.merge(
+            Solrizer.solr_name('system_create', :stored_sortable, type: :date) => 15.day.ago.iso8601
+          )
+        end
+        gf4.save
+
+        gf5 = GenericFile.new(title: ['Test 5 Document'], read_groups: ['public'])
+        gf5.apply_depositor_metadata('mjg36')
+        #stubbing to_solr so we know we have something significantly older
+        old_to_solr = gf5.method(:to_solr)
+        allow(gf5).to receive(:to_solr) do
+          old_to_solr.call.merge(
+            Solrizer.solr_name('system_create', :stored_sortable, type: :date) => 32.day.ago.iso8601
+          )
+        end
+        gf5.save
+      end
+      
+      it "doesn't include older documents" do
+        get :index
+        expect(response).to be_success
+        expect(assigns(:recent_documents).length).to eq 1 
+        create_times = assigns(:recent_documents).map { |d| d['system_create_dtsi'] }
+        expect(create_times).to_not include(15.days.ago.iso8601)
+      end
+      it "includes all documents in date bucket" do
+        get :index, {:year => Time.now.year}
+        expect(response).to be_success
+        expect(assigns(:recent_documents).length).to eq 3 
+      end
+      it "includes all documents in month date bucket" do
+        get :index, {:year => (Time.now - 1.month).year, :month => (Time.now - 1.month).month}
+        expect(response).to be_success
+        expect(assigns(:recent_documents).length).to eq 1 
+      end
+      it "excludes all documents not in date bucket" do
+        get :index, {:year => 1.year.ago.year}
+        expect(response).to be_success
+        expect(assigns(:recent_documents).length).to eq 0
+      end
+    end
+
+  end
+
+end

--- a/spec/helpers/recent_helper_spec.rb
+++ b/spec/helpers/recent_helper_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+# Specs in this file have access to a helper object that includes
+# the RecentHelper. For example:
+#
+# describe RecentHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe RecentHelper, type: :helper do
+  let(:time) { Time.new(2016) }
+  let(:bucket) { "2016-01-01T12:00:00Z" } 
+  it { expect(floor(time, 1.year)).to eq '2016-01-01T12:00:00Z' }
+  it { expect(ceil(time, 1.year)).to eq '2017-01-01T11:59:59Z' }
+  it { expect(bucket_as_date(bucket)).to eq '2016: January' }
+  it { expect(bucket_as_params(bucket)).to include(:year => 2016, :month => 1) }
+end

--- a/spec/helpers/recent_helper_spec.rb
+++ b/spec/helpers/recent_helper_spec.rb
@@ -16,5 +16,6 @@ RSpec.describe RecentHelper, type: :helper do
   it { expect(floor(time, 1.year)).to eq '2016-01-01T12:00:00Z' }
   it { expect(ceil(time, 1.year)).to eq '2017-01-01T11:59:59Z' }
   it { expect(bucket_as_date(bucket)).to eq '2016: January' }
+  it { expect(bucket_as_month(bucket)).to eq 'January' }
   it { expect(bucket_as_params(bucket)).to include(:year => 2016, :month => 1) }
 end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -96,7 +96,7 @@ describe Collection do
 
     expect(response_code).to eq 200
 
-    namespace = xml.collect_namespaces.invert['http://terms.library.library.ca/identifiers/']
+    namespace = xml.collect_namespaces.invert['http://terms.library.ualberta.ca/identifiers/']
     expect(namespace).not_to eq nil
 
     namespace = namespace.gsub(/xmlns:/, '')


### PR DESCRIPTION
* replace twitter tile on front page with most recent public upload
* recent target shows last two weeks of content by default takes year and year/month parameters.
* older documents can be reached by links to month date buckets
* fix terms.library.library.ca namespace leftover
* if you have a bunch of failing spec on sign_in make sure you're using spec_helper NOT rails_helper!