### PR TITLE
Date uploaded

### DIFF
--- a/app/models/concerns/hydranorth/generic_file/metadata.rb
+++ b/app/models/concerns/hydranorth/generic_file/metadata.rb
@@ -12,7 +12,7 @@ module Hydranorth
         # fedora's system created date will reflect the date when the record
         # was created in fedora4, but the date_uploaded will preserve the
         # original creation date from the old repository.
-        property :date_uploaded, predicate: ::RDF::DC.dateSubmitted, multiple: false do |index|
+        property :date_uploaded, predicate: ActiveFedora::RDF::Fcrepo::Model.createdDate, multiple: false do |index|
           index.type :date
           index.as :stored_sortable
         end

--- a/lib/tasks/migration.rake
+++ b/lib/tasks/migration.rake
@@ -3,7 +3,6 @@ require 'fileutils'
 require './lib/tasks/migration/migration_logger'
 require 'pdf-reader'
 require 'open3'
-require 'curb'
 
   NS = {
         "xmlns:xsi"=>"http://www.w3.org/2001/XMLSchema-instance",
@@ -342,7 +341,7 @@ namespace :migration do
         elsif type == "Thesis"
           license = "I am required to use/link to a publisher's license"
           rights = "This thesis is made available by the University of Alberta Libraries with permission of the copyright owner solely for the purpose of private, scholarly or scientific research. This thesis, or any portion thereof, may not otherwise be copied or reproduced without the written consent of the copyright owner, except to the extent permitted by Canadian copyright law."
-        elsif license=~/^.*\.(pdf|PDF|txt|TXT|doc|DOC)$/ || license.include? "..."
+        elsif license=~/^.*\.(pdf|PDF|txt|TXT|doc|DOC|\.\.\.)$/ 
           file_location = FEDORA_URL + uuid + "/LICENSE"
           MigrationLogger.info "Download license file for #{uuid}"
           license_file = "#{TEMP}/#{uuid}/LICENSE"

--- a/spec/tasks/migration_rake_spec.rb
+++ b/spec/tasks/migration_rake_spec.rb
@@ -181,7 +181,7 @@ describe "Migration rake tasks", :integration => true do
       expect(subject.content.latest_version.label).to eq "version1"
       expect(subject.fedora3foxml.latest_version.label).to eq "version1"
       expect(subject.license).to eq "I am required to use/link to a publisher's license"
-      expect(subject.rights).to eq "Permission is hereby granted to the University of Alberta Libraries to reproduce single copies of this thesis and to lend or sell such copies for private, scholarly or scientific research purposes only. The author reserves all other publication and other rights in association with the copyright in the thesis and, except as herein before provided, neither the thesis nor any substantial portion thereof may be printed or otherwise reproduced in any material form whatsoever without the author's prior written permission."
+      expect(subject.rights).to eq "This thesis is made available by the University of Alberta Libraries with permission of the copyright owner solely for the purpose of private, scholarly or scientific research. This thesis, or any portion thereof, may not otherwise be copied or reproduced without the written consent of the copyright owner, except to the extent permitted by Canadian copyright law."
       expect(subject.hasCollection).to include 'Theses'
       expect(subject.hasCollectionId).to include @collection.id
       expect(subject.belongsToCommunity).to include @community.id

--- a/spec/tasks/migration_rake_spec.rb
+++ b/spec/tasks/migration_rake_spec.rb
@@ -45,6 +45,7 @@ describe "Migration rake tasks", :integration => true do
       expect(subject.content.latest_version.label).to eq "version1"
       expect(subject.fedora3foxml.latest_version.label).to eq "version1"
       expect(subject.institutional_visibility?).to be false
+      expect(subject.date_uploaded).to eq "2013-01-06T05:11:52.580Z"
 
       expect(subject.hasCollection).to include 'test collection'
       expect(subject.hasCollectionId).to include @collection.id


### PR DESCRIPTION
This PR
* changes the mapping of date_uploaded from dcterms:dateSubmitted (which is mapped to date_submitted for theses) to info:fedora/fedora-system:def/model#createdDate as part of #977 
* modifies the migration script to use info:fedora/fedora-system:def/model#createdDate for date_uploaded
* changes the theses' right statement in migration
* makes sure that always get the license datastream for right statements instead of the label #780 and part of #977 