### PR TITLE
Quick and dirty dump of GC statistics to the header

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,6 +13,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   around_filter :profile, if: -> {Rails.env.development? && params[:trace] == "1"}
+  around_filter :gc_stats, if: -> {params[:gc_stats] == "1"}
 
   before_filter :force_account_link,
                 if: -> { @current_user && @current_user.link_pending? }
@@ -38,6 +39,13 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def gc_stats
+    before = GC.stat.to_s
+    yield
+    after = GC.stat.to_s
+    response.header['X-GC-STATS-BEFORE'] = before
+    response.header['X-GC-STATS-AFTER'] = after
+  end
 
   def after_sign_in_path_for(resource)
     if current_user.admin?


### PR DESCRIPTION
When visiting a URL in the application, appending the query param ?gc_stats=1 will cause two headers to be appended to the response:

X-GC-STATS-BEFORE, containing information about the process' memory head and garbage collection runs before the request was processed

and

X-GC-STATS-AFTER, containing the same information after the request was processed.

This may allow us to identify opportunities for tuning the Ruby VM's garbage collection to perform better in Production.

@pbinkley if possible it would be good to get this merged for Henry's deploy of Sprint 40 on Monday.