### PR TITLE
Restore correct ualterms namespace

### DIFF
--- a/lib/rdf_vocabularies/ualterms.rb
+++ b/lib/rdf_vocabularies/ualterms.rb
@@ -1,4 +1,4 @@
-class UALTerms < RDF::Vocabulary("http://terms.library.ualberta.ca/")
+class UALTerms < RDF::Vocabulary("http://terms.library.ualberta.ca/identifiers/")
   # legacy terms, to be deprecated after PCDM
   term :ingestbatch
   term :year_created

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -96,7 +96,7 @@ describe Collection do
 
     expect(response_code).to eq 200
 
-    namespace = xml.collect_namespaces.invert['http://terms.library.ualberta.ca/']
+    namespace = xml.collect_namespaces.invert['http://terms.library.ualberta.ca/identifiers/']
     expect(namespace).not_to eq nil
 
     namespace = namespace.gsub(/xmlns:/, '')


### PR DESCRIPTION
We changed the ualterms namespace to an incorrect value; this restores it.