### PR TITLE
Handle /files/<noid>/<file> download link; closes 1071

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,9 @@ Hydranorth::Application.routes.draw do
   get '/public/view/author/:username' => 'redirect#author'
   get '/action/submit/init/thesis/:uuid' => 'redirect#thesis'
 
+  # handle file download links below /files/<noid>  
+  get '/files/:id/*file' => 'downloads#show', format: false
+
   scope :dashboard do
 
     get '/files',             controller: 'my/files', action: :index, as: 'dashboard_files'


### PR DESCRIPTION
This is needed for the OAI and Google Analytics work.