### PR TITLE
redefining spec means `rake spec` runs tests twice fixes #1180

### DIFF
--- a/lib/tasks/spec.rake
+++ b/lib/tasks/spec.rake
@@ -3,10 +3,6 @@ require 'ci/reporter/rake/rspec'
 
 REPORT_PATH = "spec/reports"
 
-RSpec::Core::RakeTask.new(:spec, :tag) do |t, task_args|
-  t.rspec_opts = "--tag #{task_args[:tag]}" unless task_args[:tag].nil?
-end
-
 RSpec::Core::RakeTask.new(:cispec) do |t|
   t.rspec_opts = "--tag ~integration"
 end


### PR DESCRIPTION
Doesn't address @weiweishi slow running tests though...