### PR TITLE
Restore transfer handling from Sufia6

### DIFF
--- a/app/controllers/browse_controller.rb
+++ b/app/controllers/browse_controller.rb
@@ -22,9 +22,6 @@ class BrowseController < ApplicationController
   end
 
   configure_blacklight do |config|
-    #Show gallery view
-    config.view.gallery.partials = [:index_header, :index]
-    config.view.slideshow.partials = [:index]
 
     ## Default parameters to send to solr for all search-like requests. See also SolrHelper#solr_search_params
     config.default_solr_params = {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -101,11 +101,11 @@ Hydranorth::Application.routes.draw do
   get 'collections/:id/:per_page', controller: 'collections', action: :show
   get 'collections/:id/edit', controller: 'collections', action: :edit
   get 'recent', controller: 'recent', action: :index
+  get 'files/:id/*file' => 'downloads#show', format: false
   get 'files/:id' => 'downloads#show', constraints: WantsThumbnailConstraint
 
   # This must be the very last route in the file because it has a catch-all route for 404 errors.
   # This behavior seems to show up only in production mode.
   mount Sufia::Engine => '/'
-  get 'files/:id/*file' => 'downloads#show', format: false
   root to: 'homepage#index'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,11 +89,11 @@ Hydranorth::Application.routes.draw do
   get 'collections/:id/:per_page', controller: 'collections', action: :show
   get 'collections/:id/edit', controller: 'collections', action: :edit
   get 'recent', controller: 'recent', action: :index
-  get 'files/:id/*file' => 'downloads#show', format: false
   get 'files/:id' => 'downloads#show', constraints: WantsThumbnailConstraint
 
   # This must be the very last route in the file because it has a catch-all route for 404 errors.
   # This behavior seems to show up only in production mode.
   mount Sufia::Engine => '/'
+  get 'files/:id/*file' => 'downloads#show', format: false
   root to: 'homepage#index'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -82,6 +82,18 @@ Hydranorth::Application.routes.draw do
   get 'batches/:id/update_collections' => 'batch#update_collections', as: 'update_collections'
   get 'files/:id/stats' => 'generic_files#stats'
   get 'files/:id/edit' => 'generic_files#edit'
+
+# Generic file routes
+  resources :generic_files, path: :files, except: [:index, :show] do
+    member do
+      resource :featured_work, only: [:create, :destroy]
+      resources :transfers, as: :generic_file_transfers, only: [:new, :create]
+      get 'citation'
+      get 'stats'
+      post 'audit'
+    end
+  end
+
   get 'files/:id/update_collections' => 'generic_files#update_collections'
   get 'communities', controller: 'communities', action: :index
   get 'communities/logo', controller: 'communities', action: :logo


### PR DESCRIPTION
Closes #1220 by restoring Sufia 6 routing for transfers, which were overriden by changes in #1212