### PR TITLE
github parameter uses the git protocol...

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'google-api-client', '~> 0.7.1'
 
 gem 'sufia', '~> 6.2.0'
 gem 'rsolr', '~> 1.0.6' # blacklight will not load by default
-gem 'kaminari', github: 'jcoyne/kaminari', branch: 'sufia'
+gem 'kaminari', git: 'https://github.com/jcoyne/kaminari.git', branch: 'sufia'
 gem 'rdf-turtle', '1.1.7'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
@@ -67,7 +67,7 @@ gem "clamav"
 gem "pdf-reader"
 
 # to generate sitemap for google scholar et al
-gem 'sitemap', github: 'ualbertalib/rails-sitemap'
+gem 'sitemap', git: 'https://github.com/ualbertalib/rails-sitemap.git'
 
 # to fetch noid from fedora for reindex job
 gem 'rest-client'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/jcoyne/kaminari.git
+  remote: https://github.com/jcoyne/kaminari.git
   revision: 7f7108e12bdd64eb5a76177633768feb14df5453
   branch: sufia
   specs:
@@ -8,7 +8,7 @@ GIT
       activesupport (>= 3.0.0)
 
 GIT
-  remote: git://github.com/ualbertalib/rails-sitemap.git
+  remote: https://github.com/ualbertalib/rails-sitemap.git
   revision: b5552f24c6aba99596733a3415cb1ccdc6d9bf7a
   specs:
     sitemap (0.3.3)
@@ -767,4 +767,4 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
 
 BUNDLED WITH
-   1.12.5
+   1.13.3


### PR DESCRIPTION
... which transmits data without encryption. Use https instead.

From Bundler: 

> http:// and git:// URLs should be avoided if at all possible. These protocols are unauthenticated, so a man-in-the-middle attacker can deliver malicious code and compromise your system. HTTPS and SSH are strongly preferred.

More Info can be found here regarding this:
http://bundler.io/v1.13/man/gemfile.5.html#GIT
http://bundler.io/v1.13/man/gemfile.5.html#GITHUB