### PR TITLE
uses fcrepo_wrapper to provide Fedora 4.7 to dev environment fixes #1034

### DIFF
--- a/.fcrepo_wrapper
+++ b/.fcrepo_wrapper
@@ -1,0 +1,7 @@
+port: 8984
+enable_jms: false
+fcrepo_home_dir: tmp/fcrepo4-development-data
+version: 4.7.0
+verbose: true
+java_options:
+ - "-Dlogback.configurationFile=fedora_conf/logback.xml"

--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,8 @@ group :development, :test do
   gem "rspec-rails"
   gem "ruby-debug-passenger"
   gem "selenium-webdriver"
-  gem "jettywrapper"
+  gem "jettywrapper", require: false
+  gem "fcrepo_wrapper", require: false
   gem "capybara"
   gem "poltergeist", "~> 1.5"
   gem "factory_girl_rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -215,6 +215,8 @@ GEM
     faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
     fastercsv (1.5.5)
+    fcrepo_wrapper (0.7.0)
+      ruby-progressbar
     ffi (1.9.10)
     font-awesome-rails (4.4.0.0)
       railties (>= 3.2, < 5.0)
@@ -559,6 +561,7 @@ GEM
       oauth2
     ruby-debug-passenger (0.2.0)
     ruby-prof (0.15.9)
+    ruby-progressbar (1.8.1)
     ruby-rc4 (0.1.5)
     ruby2ruby (2.2.0)
       ruby_parser (~> 3.1)
@@ -727,6 +730,7 @@ DEPENDENCIES
   devise
   devise-guests (~> 0.3)
   factory_girl_rails
+  fcrepo_wrapper
   google-api-client (~> 0.7.1)
   jbuilder (~> 2.0)
   jettywrapper

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Dependencies:
  * clamav
 * backing store
  * Solr 4.10.3
- * Fedora 4.1 with authorization
+ * Fedora 4.7
  * MySQL
 
 To Install Application:
@@ -53,14 +53,17 @@ Relative to the application directory
 
 * **Application** ```log/<RAILS_ENV>.log```
 * **Jetty** ```jetty/jettywrapper.log```
-* **Solr/Fedora** ```jetty/logs```
+* **Solr** ```jetty/logs```
+* **Fedora** ```log/fcrepo.log```
 * **Resque** ```log/resque-pool.std[err|out].log```
 
 To Restart Components
 ---
 The shell script `bin/restart-all` runs these commands:
-* Jetty
+* Jetty/Solr
  * ```cd /var/www/sites/hydranorth && rake jetty:restart```
+* Fedora
+ * ```cd /var/www/sites/hydranorth && rake fcrepo:restart```
 * Resque/Redis
  * ```service resque-pool restart```
 * Rails/Passenger/Httpd
@@ -69,13 +72,19 @@ The shell script `bin/restart-all` runs these commands:
 To Reset Components
 ---
 The shell script `bin/reset-all` runs these commands:
- * Jetty
+ * Jetty/Solr
 
 ```
   rake jetty:stop
   rake jetty:clean
   rake sufia:jetty:config
   rake jetty:start
+```
+ * Fedora
+```
+  rake fcrepo:stop
+  rake fcrepo:clean
+  rake fcrepo:start
 ```
  * Resque/Redis
 ```

--- a/bin/reset-all
+++ b/bin/reset-all
@@ -7,6 +7,11 @@ then
   bundle exec rake jetty:clean
   bundle exec rake sufia:jetty:config
   bundle exec rake jetty:start
+
+  bundle exec rake fcrepo:stop
+  bundle exec rake fcrepo:clean
+  bundle exec rake fcrepo:start
+
   redis-cli flushall
   # wait for jetty to be available on port 8983
   sleep 30

--- a/bin/restart-all
+++ b/bin/restart-all
@@ -1,5 +1,6 @@
 #!/bin/bash
 cd /var/www/sites/hydranorth && rake jetty:restart
+cd /var/www/sites/hydranorth && rake fcrepo:restart
 # kill old resque workers
 kill -9  `ps aux | grep [r]esque | grep -v grep | cut -c 10-16`
 service resque-pool start

--- a/config/fedora.yml
+++ b/config/fedora.yml
@@ -1,15 +1,15 @@
 development:
   user: fedoraAdmin
   password: fedoraAdmin
-  url: http://127.0.0.1:8983/fedora/rest
+  url: http://127.0.0.1:8984/rest
   base_path: /dev
 test:
   user: fedoraAdmin
   password: fedoraAdmin
-  url: http://localhost:8983/fedora/rest
+  url: http://localhost:8984/rest
   base_path: /test
 production:
   user: fedoraAdmin
   password: fedoraAdmin
-  url: http://127.0.0.1:8983/fedora/rest
+  url: http://127.0.0.1:8984/rest
   base_path: /prod

--- a/fedora_conf/logback.xml
+++ b/fedora_conf/logback.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE configuration>
+<configuration>
+  <property name="FCREPO_LOG_PATH" value="log/fcrepo${logfile.extension:-.log}"/>
+  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>${FCREPO_LOG_PATH}</file>
+    <encoder>
+      <pattern>%d{dd-MMM HH:mm:ss.SSS} [%thread] %-5level %logger{35} - %msg %n</pattern>
+    </encoder>
+ 
+    <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+      <maxIndex>5</maxIndex>
+      <minIndex>1</minIndex>
+      <fileNamePattern>${FCREPO_LOG_PATH}.%i.gz</fileNamePattern>
+    </rollingPolicy>
+ 
+    <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+      <maxFileSize>20MB</maxFileSize>
+    </triggeringPolicy>
+  </appender>
+  
+  <logger name="org.fcrepo.auth" additivity="false" level="${log.fcrepo.auth:-null}">
+    <appender-ref ref="FILE"/>
+  </logger>
+ 
+  <logger name="org.fcrepo.connector.file" additivity="false" level="${log.fcrepo.connector.file:-null}">
+    <appender-ref ref="FILE"/>
+  </logger>
+ 
+  <logger name="org.fcrepo.http.api" additivity="false" level="${log.fcrepo.http.api:-null}">
+    <appender-ref ref="FILE"/>
+  </logger>
+ 
+  <logger name="org.fcrepo.http.commons" additivity="false" level="${log.fcrepo.http.commons:-null}">
+    <appender-ref ref="FILE"/>
+  </logger>
+ 
+  <logger name="org.fcrepo.jms" additivity="false" level="${log.fcrepo.jms:-null}">
+    <appender-ref ref="FILE"/>
+  </logger>
+ 
+  <logger name="org.fcrepo.kernel" additivity="false" level="${log.fcrepo.kernel:-null}">
+    <appender-ref ref="FILE"/>
+  </logger>
+ 
+  <logger name="org.fcrepo.transform" additivity="false" level="${log.fcrepo.transform:-null}">
+    <appender-ref ref="FILE"/>
+  </logger>
+ 
+  <logger name="org.fcrepo" additivity="false" level="${log.fcrepo:-INFO}">
+    <appender-ref ref="FILE"/>
+  </logger>
+ 
+  <logger name="org.apache.activemq" additivity="false" level="WARN">
+    <appender-ref ref="FILE"/>
+  </logger>
+  
+  <root additivity="false" level="WARN">
+    <appender-ref ref="FILE"/>
+  </root>
+</configuration>

--- a/lib/tasks/jetty.rake
+++ b/lib/tasks/jetty.rake
@@ -1,2 +1,4 @@
 require 'jettywrapper'
+require 'fcrepo_wrapper/rake_task'
+
 Jettywrapper.hydra_jetty_version = "v8.2.1"

--- a/lib/tasks/repair_collections_refs.rake
+++ b/lib/tasks/repair_collections_refs.rake
@@ -3,10 +3,10 @@ namespace :hydranorth do
   
   task :repair_collections_refs => :environment do
     GenericFile.all.each do |file|
-      response, xml = Hydranorth::RawFedora.get(file.id, 'fcr:export', format: 'jcr/xml')
+      response, xml = Hydranorth::RawFedora.get(file.id)
       next unless response == 200
       
-      unless xml.xpath('//sv:property[@sv:name="ns002:hasCollection_ref"]').empty?
+      unless xml.xpath('//ns002:hasCollection_ref').empty?
         c = Collection.find(file.hasCollectionId.first)
         
         # removing and re-adding the file should replace the file's collection_ref

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -92,7 +92,7 @@ describe Collection do
 
   it "should not insert a hasCollection_ref instead of hasCollection" do
     subject.add_member_ids [file.id]
-    response_code, xml = Hydranorth::RawFedora.get(file.id, '/fcr:export', format: 'jcr/xml')
+    response_code, xml = Hydranorth::RawFedora.get(file.id)
 
     expect(response_code).to eq 200
 
@@ -101,9 +101,9 @@ describe Collection do
 
     namespace = namespace.gsub(/xmlns:/, '')
 
-    expect(xml.xpath(%Q|//sv:property[@sv:name="#{namespace}:hasCollection"]|)).not_to be_empty
-    expect(xml.xpath(%Q|//sv:property[@sv:name="#{namespace}:hasCollection_ref"]|)).to be_empty
-    expect(xml.xpath(%Q|//sv:property[@sv:name="#{namespace}:hasCollection"]|).first.inner_text).to eq 'A title'
+    expect(xml.xpath(%Q|//#{namespace}:hasCollection|)).not_to be_empty
+    expect(xml.xpath(%Q|//#{namespace}:hasCollection_ref|)).to be_empty
+    expect(xml.xpath(%Q|//#{namespace}:hasCollection|).first.inner_text).to eq 'A title'
   end
 
 end


### PR DESCRIPTION
 * fcr:export was deprecated
 * configured logging
 * updated reset-all and restart-all scripts
 * updated README