### PR TITLE
DOI allow smarter recovery after a fail job happens

### DIFF
--- a/app/models/concerns/hydranorth/generic_file/doi_states.rb
+++ b/app/models/concerns/hydranorth/generic_file/doi_states.rb
@@ -56,6 +56,10 @@ module Hydranorth
         end
 
         def handle_doi_states
+          # ActiveFedora doesn't have skip_callbacks built in? So handle this ourselves.
+          # Allow this logic to be skipped if skip_handle_doi_states is set.
+          # This is mainly used so we can rollback the state when a job fails and
+          # we do not wish to rerun all this logic again which would queue up the same job again
           if skip_handle_doi_states.blank?
             return if !doi_fields_present?
 
@@ -72,6 +76,7 @@ module Hydranorth
               end
             end
           else
+            # Return it back to false, so callback can run on the next save
             self.skip_handle_doi_states = false
           end
         end

--- a/lib/hydranorth/doi_service.rb
+++ b/lib/hydranorth/doi_service.rb
@@ -35,8 +35,12 @@ module Hydranorth
             @generic_file.synced!
             ezid_identifer
           end
+        # EZID API call has probably failed so let's roll back to previous state change
         rescue Exception => e
-          # EZID API call has failed so roll back to previous state change
+          # Skip the next handle_doi_states after_save callback and roll back
+          # the state to it's previous value. By skipping the callback we can prevent
+          # it temporarily from queueing another job. As this could make it end up
+          # right back here again resulting in an infinite loop.
           @generic_file.skip_handle_doi_states = true
           @generic_file.unpublish!
 
@@ -57,8 +61,12 @@ module Hydranorth
             end
             ezid_identifer
           end
+        # EZID API call has failed so roll back to previous state change
         rescue Exception => e
-          # EZID API call has failed so roll back to previous state change
+          # Skip the next handle_doi_states after_save callback and roll back
+          # the state to it's previous value. By skipping the callback we can prevent
+          # it temporarily from queueing another job. As this could make it end up
+          # right back here again resulting in an infinite loop.
           @generic_file.skip_handle_doi_states = true
           if @generic_file.private?
             @generic_file.synced!

--- a/spec/features/analytics_spec.rb
+++ b/spec/features/analytics_spec.rb
@@ -9,7 +9,7 @@ describe 'analytics', :type => :feature, :js => true do
       f.creator = ['little_file-1.txt_creator']
       f.resource_type = ["Thesis" ]
       f.read_groups = ['public']
-      f.aasm_state = 'unminted'
+      f.aasm_state = 'excluded'
       f.apply_depositor_metadata(user.user_key)
       f.add_file(File.open('lib/tasks/migration/stats/ga_stats.txt'), path: 'era1stats', original_name: 'ga_stats.txt', mime_type: 'text/xml')
       f.save!
@@ -22,7 +22,7 @@ describe 'analytics', :type => :feature, :js => true do
       f.creator = ['little_file-2.txt_creator']
       f.resource_type = ["Thesis" ]
       f.read_groups = ['public']
-      f.aasm_state = 'unminted'
+      f.aasm_state = 'excluded'
       f.apply_depositor_metadata(user.user_key)
       f.add_file(File.open('lib/tasks/migration/stats/ga_stats_2.txt'), path: 'era1stats', original_name: 'ga_stats_2.txt', mime_type: 'text/xml')
       f.save!

--- a/spec/features/edit_thesis_spec.rb
+++ b/spec/features/edit_thesis_spec.rb
@@ -9,7 +9,7 @@ describe 'edit file', :type => :feature do
       f.creator = ['little_file.txt_creator']
       f.resource_type = ["Thesis" ]
       f.read_groups = ['public']
-      f.aasm_state = 'unminted'
+      f.aasm_state = 'excluded'
       f.apply_depositor_metadata(user.user_key)
       f.save!
     end

--- a/spec/features/resource_types_spec.rb
+++ b/spec/features/resource_types_spec.rb
@@ -10,7 +10,7 @@ describe 'Edit resource form', :type => :feature do
       f.creator = ['little_file.txt_creator']
       f.resource_type = ["Book"]
       f.read_groups = ['public']
-      f.aasm_state = 'unminted'
+      f.aasm_state = 'excluded'
       f.apply_depositor_metadata(user.user_key)
       f.save!
     end
@@ -21,7 +21,7 @@ describe 'Edit resource form', :type => :feature do
       f.creator = ['little_file.txt_creator']
       f.resource_type = ["Book"]
       f.read_groups = ['public']
-      f.aasm_state = 'unminted'
+      f.aasm_state = 'excluded'
       f.apply_depositor_metadata(admin.user_key)
       f.save!
     end

--- a/spec/lib/hydranorth/doi_service_spec.rb
+++ b/spec/lib/hydranorth/doi_service_spec.rb
@@ -37,6 +37,23 @@ describe Hydranorth::DOIService do
         expect(generic_file.aasm_state).to eq('available')
       end
     end
+
+    it 'should rollback to proper state if EZID fails' do
+      expect(generic_file.doi).to eq(nil)
+      VCR.use_cassette('ezid_minting_failure') do
+        generic_file.aasm_state = 'unminted'
+        generic_file.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+        generic_file.save!
+
+        expect { Hydranorth::DOIService.new(generic_file).create }.to raise_error(Ezid::Error, 'bad request - password required')
+
+        generic_file.reload
+
+        expect(generic_file.doi).to eq(nil)
+        expect(generic_file.aasm_state).to eq('not_available')
+        expect(generic_file.skip_handle_doi_states).to eq(false)
+      end
+    end
   end
 
   describe '#update' do
@@ -49,7 +66,7 @@ describe Hydranorth::DOIService do
 
     it 'should successfully update when passing in valid doi and metadata' do
       VCR.use_cassette('ezid_updating') do
-        generic_file.aasm_state = 'unsynced'
+        generic_file.aasm_state = 'awaiting_update'
         generic_file.doi = example_doi_id
         generic_file.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
         generic_file.title = ['Different Title']
@@ -68,7 +85,7 @@ describe Hydranorth::DOIService do
 
     it 'should successfully update to unavailable when private' do
       VCR.use_cassette('ezid_updating_unavailable') do
-        generic_file.aasm_state = 'unsynced'
+        generic_file.aasm_state = 'awaiting_update'
         generic_file.doi = example_doi_id
         generic_file.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
         generic_file.save
@@ -79,10 +96,39 @@ describe Hydranorth::DOIService do
         expect(ezid_identifer.status).to eq('unavailable | not publicly released')
         expect(ezid_identifer.export).to eq('no')
         generic_file.reload
-        expect(generic_file.aasm_state).to eq('unpublished')
+        expect(generic_file.aasm_state).to eq('not_available')
       end
     end
 
+    it 'should rollback to proper state if EZID fails when private' do
+      VCR.use_cassette('ezid_updating_failure') do
+        generic_file.aasm_state = 'awaiting_update'
+        generic_file.doi = example_doi_id
+        generic_file.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
+        generic_file.save!
+
+        expect { Hydranorth::DOIService.new(generic_file).update }.to raise_error(Ezid::Error, 'bad request - password required')
+
+        generic_file.reload
+        expect(generic_file.aasm_state).to eq('available')
+        expect(generic_file.skip_handle_doi_states).to eq(false)
+      end
+    end
+
+    it 'should rollback to proper state if EZID fails when public' do
+      VCR.use_cassette('ezid_updating_failure') do
+        generic_file.aasm_state = 'awaiting_update'
+        generic_file.doi = example_doi_id
+        generic_file.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+        generic_file.save!
+
+        expect { Hydranorth::DOIService.new(generic_file).update }.to raise_error(Ezid::Error, 'bad request - password required')
+
+        generic_file.reload
+        expect(generic_file.aasm_state).to eq('not_available')
+        expect(generic_file.skip_handle_doi_states).to eq(false)
+      end
+    end
   end
 
   describe '.remove' do

--- a/spec/models/generic_file_spec.rb
+++ b/spec/models/generic_file_spec.rb
@@ -245,7 +245,7 @@ describe GenericFile, :type => :model do
       new_generic_file.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
       new_generic_file.save
       new_generic_file.reload
-      expect(new_generic_file.aasm_state).to eq('unpublished')
+      expect(new_generic_file.aasm_state).to eq('not_available')
       expect(enqueued_jobs.count).to eq(0)
     end
 
@@ -256,12 +256,21 @@ describe GenericFile, :type => :model do
       expect(enqueued_jobs.count).to eq(1)
     end
 
+    it 'should not mint a new file that is public if #skip_handle_doi_states is true' do
+      new_generic_file.skip_handle_doi_states = true
+      new_generic_file.save
+      new_generic_file.reload
+      expect(new_generic_file.aasm_state).to eq('not_available')
+      expect(new_generic_file.skip_handle_doi_states).to eq(false) # rollsback to false
+      expect(enqueued_jobs.count).to eq(0)
+    end
+
     it 'should update doi when file is public and a changes to doi field happen' do
       generic_file.title = ['Diff Title']
       generic_file.save
 
       generic_file.reload
-      expect(generic_file.aasm_state).to eq('unsynced')
+      expect(generic_file.aasm_state).to eq('awaiting_update')
       expect(enqueued_jobs.count).to eq(1)
     end
 
@@ -288,24 +297,24 @@ describe GenericFile, :type => :model do
       generic_file.save
 
       generic_file.reload
-      expect(generic_file.aasm_state).to eq('unsynced')
+      expect(generic_file.aasm_state).to eq('awaiting_update')
       expect(enqueued_jobs.count).to eq(1)
     end
 
     it 'should update doi when file changes visibility from private to public' do
       new_generic_file.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE
-      new_generic_file.aasm_state = 'unpublished'
+      new_generic_file.aasm_state = 'not_available'
       new_generic_file.doi = 'doi:10.5072/FKEXAMPLE'
       new_generic_file.save
 
       new_generic_file.reload
-      expect(new_generic_file.aasm_state).to eq('unpublished')
+      expect(new_generic_file.aasm_state).to eq('not_available')
       expect(enqueued_jobs.count).to eq(0)
 
       new_generic_file.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
       new_generic_file.save
       new_generic_file.reload
-      expect(new_generic_file.aasm_state).to eq('unsynced')
+      expect(new_generic_file.aasm_state).to eq('awaiting_update')
       expect(enqueued_jobs.count).to eq(1)
     end
 

--- a/spec/support/http_cache/vcr/ezid_minting_failure.yml
+++ b/spec/support/http_cache/vcr/ezid_minting_failure.yml
@@ -1,0 +1,55 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://ezid.cdlib.org/shoulder/doi:10.5072/FK2
+    body:
+      encoding: UTF-8
+      string: |-
+        _status: public
+        _profile: datacite
+        datacite.creator: John Doe
+        datacite.publisher: University of Alberta Libraries
+        datacite.publicationyear: (:unav)
+        datacite.resourcetype: Text/Book
+        datacite.title: Test Title
+        _target: http://localhost:3000/files/0p096808h
+        _export: yes
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - ezid.cdlib.org
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Authorization:
+      - Basic YXBpdGVhc2RzdDo=
+  response:
+    status:
+      code: 400
+      message: BAD REQUEST
+    headers:
+      Date:
+      - Mon, 05 Dec 2016 22:48:25 GMT
+      Server:
+      - Apache/2.2.17 (Unix) mod_ssl/2.2.17 OpenSSL/1.0.1k-fips mod_wsgi/4.4.9 Python/2.7.6
+      Content-Length:
+      - '38'
+      Vary:
+      - Accept-Language,Cookie
+      Content-Language:
+      - en
+      Connection:
+      - close
+      Content-Type:
+      - text/plain; charset=UTF-8
+    body:
+      encoding: UTF-8
+      string: 'error: bad request - password required'
+    http_version: 
+  recorded_at: Mon, 05 Dec 2016 22:48:25 GMT
+recorded_with: VCR 3.0.3

--- a/spec/support/http_cache/vcr/ezid_updating_failure.yml
+++ b/spec/support/http_cache/vcr/ezid_updating_failure.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://ezid.cdlib.org/id/doi:10.5072/FK2JQ1003W
+    body:
+      encoding: UTF-8
+      string: |-
+        datacite.creator: John Doe
+        datacite.publisher: University of Alberta Libraries
+        datacite.publicationyear: (:unav)
+        datacite.resourcetype: Text/Book
+        datacite.title: Test Title
+        _target: http://localhost:3000/files/7m01bn033
+        _status: unavailable | not publicly released
+        _export: no
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - ezid.cdlib.org
+      Content-Type:
+      - text/plain; charset=UTF-8
+      Authorization:
+      - Basic YXBpdGVhc2RzdDo=
+  response:
+    status:
+      code: 400
+      message: BAD REQUEST
+    headers:
+      Date:
+      - Mon, 05 Dec 2016 22:48:30 GMT
+      Server:
+      - Apache/2.2.17 (Unix) mod_ssl/2.2.17 OpenSSL/1.0.1k-fips mod_wsgi/4.4.9 Python/2.7.6
+      Content-Length:
+      - '38'
+      Vary:
+      - Accept-Language,Cookie
+      Content-Language:
+      - en
+      Connection:
+      - close
+      Content-Type:
+      - text/plain; charset=UTF-8
+    body:
+      encoding: UTF-8
+      string: 'error: bad request - password required'
+    http_version: 
+  recorded_at: Mon, 05 Dec 2016 22:48:30 GMT
+recorded_with: VCR 3.0.3

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -3,6 +3,7 @@
 # https://relishapp.com/vcr/vcr/docs
 # http://www.rubydoc.info/gems/vcr/frames
 require 'vcr'
+require 'webmock/rspec'
 
 VCR.configure do |config|
   config.cassette_library_dir = 'spec/support/http_cache/vcr'


### PR DESCRIPTION
View PR https://github.com/ualbertalib/HydraNorth/pull/1320 first. This is a continuation of work. Mainly look at this commit: https://github.com/ualbertalib/HydraNorth/pull/1326/commits/131f0ff16ee50c72c22cf92e6fa2d014846d019b

This fixes an issue when potentially GenericFiles can become stuck in a state where they can no longer be minted or updated for DOI's. Previously if a job fails (for whatever reason such as bad config, EZID API is down, etc.), then the GenericFile will be stuck in a purgatory state (unminted/awaiting_update). And will never be able to do anything with DOI's unless a developer fixes this bad state. Which isn't ideal. This commit will add the behaviour of rolling back the GF to a usable state if it fails when interacting with EZID.