### PR TITLE
Add DOI meta tags on generic file show page

### DIFF
--- a/app/views/generic_files/show.html.erb
+++ b/app/views/generic_files/show.html.erb
@@ -23,6 +23,10 @@
   <% end %>
   <meta name="citation_publication_date" content="<%= @presenter.date_created %>"/>
   <meta name="citation_pdf_url" content="<%= download_url(@presenter) %>"/>
+  <% if @presenter.doi.present? %>
+    <meta name="dc.identifier" content="<%= @presenter.doi %>">
+    <meta name="citation_doi" content="<%= @presenter.doi %>">
+  <% end %>
   <!-- Sufia does not yet support these metadata -->
   <!--
     <meta name="citation_journal_title" content=""/>


### PR DESCRIPTION
This fixes #1333. See issue for more details.

This will add two new metatags to the bottom of the Google Scholar metadata source code for a generic file only and only if it has a DOI available (otherwise nothing will be added):

```html
    <!-- Google Scholar metadata -->
    <meta name="citation_title" content="zxczxczcz"/>
    <meta name="citation_author" content="addfsdf"/>
    <meta name="citation_publication_date" content=""/>
    <meta name="citation_pdf_url" content="http://localhost/files/5x21tg860/spring.rb"/>
    <meta name="dc.identifier" content="doi:10.5072/FK26T0P60G">
    <meta name="citation_doi" content="doi:10.5072/FK26T0P60G">
```