### PR TITLE
Minor fixes to migration.rake: set coll/comm on command line, handle source/relation

### DIFF
--- a/lib/tasks/migration.rake
+++ b/lib/tasks/migration.rake
@@ -74,15 +74,17 @@ namespace :migration do
   end
 
   desc "batch migrate generic files from modified ERA FOXML file"
-  task :eraitem, [:dir, :migrate_datastreams] => :environment do |t, args|
+  task :eraitem, [:dir, :migrate_datastreams, :usecomm, :usecoll] => :environment do |t, args|
     args.with_defaults(:migrate_datastreams => "true")
     begin
       MigrationLogger.info "**************START: Migrate ERA objects *******************"
       metadata_dir = args.dir
       migrate_datastreams = args.migrate_datastreams == "true"
-      # Usage: Rake migration:eraitem[<file directory here, path included>,<optional: migrate_datastreams: boolean>]
+      usecomm = args.usecomm
+      usecoll = args.usecoll
+      # Usage: Rake migration:eraitem[<file directory here, path included>,<optional: migrate_datastreams: boolean>,<optional: usecomm: NOID>,<optional: usecoll: NOID]
       if File.exist?(metadata_dir) && File.directory?(metadata_dir)
-        migrate_object(metadata_dir, migrate_datastreams)
+        migrate_object(metadata_dir, migrate_datastreams, usecomm, usecoll)
       else
         MigrationLogger.fatal "Invalid directory #{metadata_dir}"
       end
@@ -159,7 +161,7 @@ namespace :migration do
     end
   end
 
-  def migrate_object(metadata_dir, migrate_datastreams)
+  def migrate_object(metadata_dir, migrate_datastreams, usecomm, usecoll)
     time = Time.now
     metadata_time = 0
     attr_time = 0
@@ -466,12 +468,20 @@ namespace :migration do
 
      # find communities and collections information based on UUID
      communities_noid = []
-     communities.each do |cuuid|
-       communities_noid << find_collection(cuuid)
+     if usecomm
+       communities_noid << usecomm
+     else
+       communities.each do |cuuid|
+         communities_noid << find_collection(cuuid)
+       end
      end
      collections_noid = []
-     collections.each do |cuuid|
-       collections_noid << find_collection(cuuid)
+     if usecoll
+       collections_noid << usecoll
+     else
+       collections.each do |cuuid|
+         collections_noid << find_collection(cuuid)
+       end
      end
 
      collections_title = []

--- a/lib/tasks/migration.rake
+++ b/lib/tasks/migration.rake
@@ -231,6 +231,8 @@ namespace :migration do
       is_version_of = dc_version.xpath("dcterms:isVersionOf", MigrationConstants::NS).text().gsub(/\n/,'|').gsub(/\t/,' ') unless dc_version.xpath("dcterms:isVersionOf", MigrationConstants::NS).blank?
       is_version_of ||= dc_version.xpath("dcterms:isversionof", MigrationConstants::NS).text().gsub(/\n/,'|').gsub(/\t/,' ') if dc_version.xpath("dcterms:isversionof", MigrationConstants::NS)
       is_version_of = HTMLEntities.new.decode(is_version_of)
+      source = dc_version.xpath("dcterms:source", MigrationConstants::NS).text()
+      relation = dc_version.xpath("dcterms:relation", MigrationConstants::NS).text()
       if type == "Thesis"
       #for thesis objects
       abstract = dc_version.xpath("dcterms:abstract", MigrationConstants::NS).text().gsub(/\n/,' ').gsub(/\t/,' ') if dc_version.xpath("dcterms:abstract", MigrationConstants::NS)
@@ -545,7 +547,7 @@ namespace :migration do
       # add other metadata to the new object
       @generic_file.label ||= original_filename
       @generic_file.title = [title]
-      file_attributes = {"resource_type"=>[type], "contributor"=>contributors, "description"=>[description], "date_created"=>date, "year_created"=>year_created, "license"=>license, "rights"=>rights, "subject"=>subjects, "spatial"=>spatials, "temporal"=>temporals, "language"=>LANG.fetch(language), "fedora3uuid"=>uuid, "fedora3handle" => fedora3handle, "trid" => trid, "ser" => ser, "abstract" => abstract, "date_accepted" => date_accepted, "date_submitted" => date_submitted, "is_version_of" => is_version_of, "graduation_date" => graduation_date, "specialization" => specialization, "supervisor" => supervisors, "committee_member" => committee_members, "department" => departments, "thesis_name" => thesis_name, "thesis_level" => thesis_level, "alternative_title" => alternative_titles, "proquest" => proquest, "unicorn" => unicorn, "degree_grantor" => degree_grantor, "dissertant" => dissertant,  "ingestbatch" => @ingest_batch_id, "belongsToCommunity" => communities_noid, "hasCollectionId" => collections_noid, "hasCollection" => collections_title}
+      file_attributes = {"resource_type"=>[type], "contributor"=>contributors, "description"=>[description], "date_created"=>date, "year_created"=>year_created, "license"=>license, "rights"=>rights, "subject"=>subjects, "spatial"=>spatials, "temporal"=>temporals, "language"=>LANG.fetch(language), "fedora3uuid"=>uuid, "fedora3handle" => fedora3handle, "trid" => trid, "ser" => ser, "abstract" => abstract, "date_accepted" => date_accepted, "date_submitted" => date_submitted, "is_version_of" => is_version_of, "graduation_date" => graduation_date, "specialization" => specialization, "supervisor" => supervisors, "committee_member" => committee_members, "department" => departments, "thesis_name" => thesis_name, "thesis_level" => thesis_level, "alternative_title" => alternative_titles, "proquest" => proquest, "unicorn" => unicorn, "degree_grantor" => degree_grantor, "dissertant" => dissertant, "source" => source, "related_url" => relation, "ingestbatch" => @ingest_batch_id, "belongsToCommunity" => communities_noid, "hasCollectionId" => collections_noid, "hasCollection" => collections_title}
       @generic_file.attributes = file_attributes
       if item_state == 'Inactive'
         if embargoed


### PR DESCRIPTION
Two minor fixes to facilitate loading the radioactive records:

- Allow passing the community and collection urls on the command line, which makes loading non-migrated items easier (i.e. which don't correspond to an item in old ERA)
- Handle the dcterms:source and dcterms:relation fields, mapping them to GenericFile.source and .related_url