### PR TITLE
Fix gemfile.lock issue concerning nokogiri

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -761,6 +761,7 @@ DEPENDENCIES
   listen (~> 3.0.5)
   mysql2 (~> 0.3.2)
   noid (~> 0.8)
+  nokogiri (~> 1.7.1)
   omniauth-shibboleth
   pdf-reader
   poltergeist (~> 1.5)
@@ -790,4 +791,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.13.6
+   1.14.6


### PR DESCRIPTION
Fixes this error from happening:
```
You are trying to install in deployment mode after changing
your Gemfile. Run `bundle install` elsewhere and add the
updated Gemfile.lock to version control.

If this is a development machine, remove the /home/murny/Code/HydraNorth/Gemfile freeze 
by running `bundle install --no-deployment`.

the dependencies in your gemfile changed


You have added to the Gemfile:
* nokogiri (~> 1.7.1)
```