### PR TITLE
use existing Redis connection for preservation queue

### DIFF
--- a/lib/hydranorth/preservation_queue.rb
+++ b/lib/hydranorth/preservation_queue.rb
@@ -5,7 +5,7 @@ module Hydranorth::PreservationQueue
   QUEUE_NAME = Rails.application.secrets.preservation_queue_name
 
   def queue
-    $queue ||= ConnectionPool.new({size: 1, timeout: 5}) { Redis.new }
+    $queue ||= ConnectionPool.new({size: 1, timeout: 5}) { Redis.current }
   end
 
   def preserve(noid)


### PR DESCRIPTION
use existing Redis connection for preservation queue instead of creating a new redis connection. 