### PR TITLE
updated robot.txt to avoid crawling the item stats page

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -7,4 +7,7 @@
 User-agent: *
 Disallow: /catalog
 
+User-agent: *
+Disallow: /files/*/stats
+
 Sitemap: https://era.library.ualberta.ca/sitemap.xml


### PR DESCRIPTION
All the error message related to #1399 are caused by bots trying to crawl the item stats page. The stats page does send an API request to Google Analytics. By blocking the bots from crawling this page, we will fix the majority occurrences of this issue, and can see if anything else could be causing it. 
