### PR TITLE
remove unnecessary error handling in pushing to preservation queue

### DIFF
--- a/lib/hydranorth/preservation_queue.rb
+++ b/lib/hydranorth/preservation_queue.rb
@@ -11,7 +11,6 @@ module Hydranorth::PreservationQueue
   def preserve(noid)
     queue.with do |conn|
       status = conn.zadd QUEUE_NAME, Time.now.to_f, noid
-      raise PreservationError unless status == true
     end
     # rescue all preservation errors so that the user can continue to use the application normally
   rescue StandardError => e

--- a/lib/hydranorth/preservation_queue.rb
+++ b/lib/hydranorth/preservation_queue.rb
@@ -1,7 +1,5 @@
 module Hydranorth::PreservationQueue
 
-  class PreservationError < StandardError; end
-
   QUEUE_NAME = Rails.application.secrets.preservation_queue_name
 
   def queue


### PR DESCRIPTION
To address all the "Can't Preserve..." error messages in Rollbar